### PR TITLE
Introduced the Cython prange for parallel execution in ufuncify_matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install sympy cython cyipopt nose coverage sphinx matplotlib
+  - conda install sympy cython cyipopt nose coverage sphinx matplotlib openmp
 script:
   - nosetests -v --with-coverage --cover-package=opty
   - python setup.py install

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ To run all of the examples the following additional dependencies are required:
 - pytables
 - pandas
 - yeadon
+- openmp
 
 **Currently only Linux and Mac are officially supported.** Although, it should
 be possible to install this on Windows with an appropriate Cython compilation

--- a/examples/parallel_example.py
+++ b/examples/parallel_example.py
@@ -1,0 +1,45 @@
+"""This script generates equations of motion that have a very large number of
+operations. It then creates a parallelized and non-parallelized version and
+compares the evaluation time."""
+
+import timeit
+
+import numpy as np
+import sympy as sm
+from pydy.models import n_link_pendulum_on_cart
+from opty.utils import ufuncify_matrix
+
+sys = n_link_pendulum_on_cart(10, False, False)
+
+c = np.random.random(int(1e7))
+
+args = [c for i in range(len(list(sys.constants_symbols) +
+                             list(sys.coordinates) + list(sys.speeds)))]
+
+res = np.empty((int(1e7), 11))
+
+udots = sm.Matrix([5.0 for u in sys.speeds])
+
+expr = sys.eom_method.mass_matrix * udots - sys.eom_method.forcing
+
+q_sub = {q: sm.Symbol(q.__class__.__name__) for q in sys.coordinates}
+
+u_sub = {u: sm.Symbol(u.__class__.__name__) for u in sys.speeds}
+
+expr = expr.subs(q_sub).subs(u_sub)
+
+f_nonpar = ufuncify_matrix(list(sys.constants_symbols) + list(q_sub.values()) +
+                           list(u_sub.values()), expr, parallel=False)
+
+f_par = ufuncify_matrix(list(sys.constants_symbols) + list(q_sub.values()) +
+                        list(u_sub.values()), expr, parallel=True)
+
+start_time = timeit.default_timer()
+f_nonpar(res, *args)
+elapsed = timeit.default_timer() - start_time
+print('Time for non-parallel: {}'.format(elapsed))
+
+start_time = timeit.default_timer()
+f_par(res, *args)
+elapsed = timeit.default_timer() - start_time
+print('Time for parallelized: {}'.format(elapsed))

--- a/opty/tests/test_utils.py
+++ b/opty/tests/test_utils.py
@@ -100,8 +100,8 @@ def test_ufuncify_matrix():
         result[:, 0, 0] = a_vals**2 * np.cos(b_vals)**c_vals
         result[:, 0, 1] = np.tan(b_vals) / np.sin(a_vals + b_vals) + c_vals**4
         result[:, 1, 0] = a_vals**2 + b_vals**2 - np.sqrt(c_vals)
-        result[:, 1, 1] = (((a_vals + b_vals + c_vals) * (a_vals + b_vals))
-                           / a_vals * np.sin(b_vals))
+        result[:, 1, 1] = (((a_vals + b_vals + c_vals) * (a_vals + b_vals)) /
+                           a_vals * np.sin(b_vals))
 
         return result
 
@@ -113,6 +113,13 @@ def test_ufuncify_matrix():
                             eval_matrix_loop_numpy(a_vals, b_vals, c_vals))
 
     f = utils.ufuncify_matrix((a, b, c), sym_mat, const=(c,))
+
+    result = np.empty((n, 4))
+
+    testing.assert_allclose(f(result, a_vals, b_vals, c_val),
+                            eval_matrix_loop_numpy(a_vals, b_vals, c_val))
+
+    f = utils.ufuncify_matrix((a, b, c), sym_mat, const=(c,), parallel=True)
 
     result = np.empty((n, 4))
 

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -111,10 +111,11 @@ void {routine_name}(double matrix[{matrix_output_size}], {input_args});
 
 _cython_template = """\
 import numpy as np
+from cython.parallel import prange
 cimport numpy as np
 cimport cython
 
-cdef extern from "{file_prefix}_h.h":
+cdef extern from "{file_prefix}_h.h" nogil:
     void {routine_name}(double matrix[{matrix_output_size}], {input_args})
 
 @cython.boundscheck(False)
@@ -125,7 +126,7 @@ def {routine_name}_loop(np.ndarray[np.double_t, ndim=2] matrix, {numpy_typed_inp
 
     cdef int i
 
-    for i in range(n):
+    for i in prange(n, nogil=True):
         {routine_name}(&matrix[i, 0], {indexed_input_args})
 
     return matrix.reshape(n, {num_rows}, {num_cols})
@@ -141,6 +142,8 @@ extension = Extension(name="{file_prefix}",
                       sources=["{file_prefix}.pyx",
                                "{file_prefix}_c.c"],
                       #extra_compile_args=["-ffast-math"],
+                      extra_compile_args=['-fopenmp'],
+                      extra_link_args=['-fopenmp'],
                       include_dirs=[numpy.get_include()])
 
 setup(name="{routine_name}",

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -7,6 +7,7 @@ import tempfile
 import subprocess
 import importlib
 from functools import wraps
+import warnings
 
 import numpy as np
 import sympy as sm
@@ -178,6 +179,7 @@ int main() {
 
     compiler = os.getenv('CC', 'cc')
 
+    exit = 1
     try:
         with open(os.devnull, 'w') as fnull:
             exit = subprocess.call([compiler, '-fopenmp', filename],
@@ -251,7 +253,16 @@ def ufuncify_matrix(args, expr, const=None, tmp_dir=None, parallel=False):
          'num_rows': expr.shape[0],
          'num_cols': expr.shape[1]}
 
-    if parallel and openmp_installed():
+    if parallel:
+        if openmp_installed():
+            openmp = True
+        else:
+            openmp = False
+            msg = ('openmp is not installed or not working properly, request '
+                   'for parallel execution ignored.')
+            warnings.warn(msg)
+
+    if parallel and openmp:
         d['loop_sig'] = "prange(n, nogil=True)"
         d['head_gil'] = " nogil"
         d['compile_args'] = "'-fopenmp'"


### PR DESCRIPTION
- [x] Add openmp as a dependency.

So this seems to work. All my cores are used to evaluate the ufuncified matrix, but there doesn't seem to be any speed gain. Here is some code to test it:

```
In [1]: from opty.utils import ufuncify_matrix

In [2]: from pydy.models import multi_mass_spring_damper
/home/moorepants/src/pydy/pydy/codegen/code.py:18: DeprecationWarning: This module, 'pydy.codgen.code', is deprecated. The function 'generate_ode_function' can be found in the 'pydy.codegen.ode_function_generator' module. 'CythonGenerator' has been removed, use 'pydy.codegen.cython_code.CythonMatrixGenerator' instead.
  DeprecationWarning)

In [3]: import numpy as np

In [4]: import sympy as sm

In [5]: sys = multi_mass_spring_damper(5)

In [6]: ms = list(sm.ordered(sys.constants_symbols))[-5:]

In [7]: m0 = np.random.random(int(1e7))

In [8]: m1 = np.random.random(int(1e7))

In [9]: m2 = np.random.random(int(1e7))

In [10]: m3 = np.random.random(int(1e7))

In [11]: m4 = np.random.random(int(1e7))

In [12]: res = np.empty((int(1e7), 25))

In [13]: f = ufuncify_matrix(ms, sys.eom_method.mass_matrix, tmp_dir='parallely')
```

For the parallel version (using my 4 cores):

```
In [14]: %timeit r = f(res, m0, m1, m2, m3, m4)
1 loops, best of 3: 573 ms per loop
```

For the single threaded version:

```
In [15]: %timeit r = f(res, m0, m1, m2, m3, m4)
1 loops, best of 3: 558 ms per loop
```

Oddly the single threaded version is faster.

**Note** that `res` is 2GB, so make sure enough memory is available.
