### PR TITLE
Made all count variable names consistent across the codebase.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
     else
       conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION;
       source activate test-environment;
-      conda install sympy cython cyipopt pytest pytest-cov coverage sphinx matplotlib-base openmp;
+      conda install sympy cython scipy cyipopt pytest pytest-cov coverage sphinx matplotlib-base openmp;
     fi
 script:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/docs/theory.rst
+++ b/docs/theory.rst
@@ -16,7 +16,7 @@ where:
   :math:`t`
 - :math:`\mathbf{r}(t) \in \mathbb{R}^m` is the vector of specified
   (exongenous) inputs at time :math:`t`
-- :math:`\mathbf{p} \in \mathbb{R}^r` is the vector of constant parameters
+- :math:`\mathbf{p} \in \mathbb{R}^p` is the vector of constant parameters
 
 From here on out, the notation :math:`(t)` will be dropped for convenience.
 
@@ -158,7 +158,7 @@ Then, defining :math:`\mathbf{x}_i` to be:
 
 .. math::
 
-   \mathbf{x}_i = [\mathbf{y}_i \quad \mathbf{r}_{ui} \quad \mathbf{p}_{ui}]^T
+   \mathbf{x}_i = [\mathbf{y}_i \quad \mathbf{r}_{ui} \quad \mathbf{p}_{u}]^T
 
 
 The above equations will create :math:`n(N-1)` constraint equations and the
@@ -166,7 +166,7 @@ optimization problem can formally be written as:
 
 .. math::
 
-   & \underset{\mathbf{x}_i \in \mathbb{R}^{(n + q)N + r}}
+   & \underset{\mathbf{x}_i \in \mathbb{R}^{n + q + r}}
               {\text{min}}
    & & J(\mathbf{x}_i) \\
    & \text{s.t.}

--- a/docs/theory.rst
+++ b/docs/theory.rst
@@ -14,9 +14,9 @@ where:
 - :math:`t` is time
 - :math:`\mathbf{y}(t) \in \mathbb{R}^n` the state vector at time
   :math:`t`
-- :math:`\mathbf{r}(t) \in \mathbb{R}^p` is the vector of specified
+- :math:`\mathbf{r}(t) \in \mathbb{R}^m` is the vector of specified
   (exongenous) inputs at time :math:`t`
-- :math:`\mathbf{p} \in \mathbb{R}^q` is the vector of constant parameters
+- :math:`\mathbf{p} \in \mathbb{R}^r` is the vector of constant parameters
 
 From here on out, the notation :math:`(t)` will be dropped for convenience.
 
@@ -58,6 +58,11 @@ One can then break up :math:`\mathbf{r}` and :math:`\mathbf{p}` into known,
    \mathbf{r} = \left[ \mathbf{r}_k \quad \mathbf{r}_u \right]^T
 
    \mathbf{p} = \left[ \mathbf{p}_k \quad \mathbf{p}_u \right]^T
+
+where the dimension of the unknown vectors are:
+
+- :math:`\mathbf{r}_u \in \mathbb{R}^q`
+- :math:`\mathbf{p}_u \in \mathbb{R}^r`
 
 Then there are optimal state trajectories :math:`\mathbf{y}`, optimal unknown
 input trajectories :math:`\mathbf{r}_u` and optimal unknown parameter values
@@ -111,7 +116,7 @@ Euler method`_ and the `midpoint method`_.
 .. _backward Euler method: https://en.wikipedia.org/wiki/Backward_Euler_method
 .. _midpoint method: https://en.wikipedia.org/wiki/Midpoint_method
 
-If :math:`h` is the time interval between the :math:`m`  discretized instances
+If :math:`h` is the time interval between the :math:`N` discretized instances
 of time :math:`t_i`, one can use the backward Euler method of integration to
 approximate the derivative of the state vector as:
 
@@ -156,12 +161,12 @@ Then, defining :math:`\mathbf{x}_i` to be:
    \mathbf{x}_i = [\mathbf{y}_i \quad \mathbf{r}_{ui} \quad \mathbf{p}_{ui}]^T
 
 
-The above equations will create :math:`nm` constraint equations and the
+The above equations will create :math:`n(N-1)` constraint equations and the
 optimization problem can formally be written as:
 
 .. math::
 
-   & \underset{\mathbf{x}_i \in \mathbb{R}^{(n + p)m + q}}
+   & \underset{\mathbf{x}_i \in \mathbb{R}^{(n + q)N + r}}
               {\text{min}}
    & & J(\mathbf{x}_i) \\
    & \text{s.t.}

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -234,7 +234,7 @@ class Problem(ipopt.problem):
 
         Returns
         =======
-        constraints_val : ndarray, shape(n*(N - 1) + numinstance)
+        constraints_val : ndarray, shape(n*(N - 1) + o)
             The value of the constraint function.
 
         Notes
@@ -244,6 +244,7 @@ class Problem(ipopt.problem):
         - n : number of unknown state trajectories
         - q : number of unknown input trajectories
         - r : number of unknown parameters
+        - o : number of instance constraints
 
         """
         # This should return a column vector.

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -178,13 +178,21 @@ class Problem(ipopt.problem):
 
         Parameters
         ==========
-        free : ndarray, (n * N + m * M + q, )
+        free : ndarray, (n*N + q*N + r, )
             A solution to the optimization problem in the canonical form.
 
         Returns
         =======
         obj_val : float
             The value of the objective function.
+
+        Notes
+        =====
+
+        - N : number of collocation nodes
+        - n : number of unknown state trajectories
+        - q : number of unknown input trajectories
+        - r : number of unknown parameters
 
         """
         return self.obj(free)
@@ -195,13 +203,21 @@ class Problem(ipopt.problem):
 
         Parameters
         ==========
-        free : ndarray, (n * N + m * M + q, )
+        free : ndarray, (n*N + q*N + r, )
             A solution to the optimization problem in the canonical form.
 
         Returns
         =======
-        gradient_val : ndarray, shape(n * N + m * M + q, 1)
+        gradient_val : ndarray, shape(n*N + q*N + r, 1)
             The value of the gradient of the objective function.
+
+        Notes
+        =====
+
+        - N : number of collocation nodes
+        - n : number of unknown state trajectories
+        - q : number of unknown input trajectories
+        - r : number of unknown parameters
 
         """
         # This should return a column vector.
@@ -213,13 +229,21 @@ class Problem(ipopt.problem):
 
         Parameters
         ==========
-        free : ndarray, (n * N + m * M + q, )
+        free : ndarray, (n*N + q*N + r, )
             A solution to the optimization problem in the canonical form.
 
         Returns
         =======
-        constraints_val : ndarray, shape(n * N -1 + numinstance)
+        constraints_val : ndarray, shape(n*(N - 1) + numinstance)
             The value of the constraint function.
+
+        Notes
+        =====
+
+        - N : number of collocation nodes
+        - n : number of unknown state trajectories
+        - q : number of unknown input trajectories
+        - r : number of unknown parameters
 
         """
         # This should return a column vector.
@@ -231,7 +255,7 @@ class Problem(ipopt.problem):
 
         Returns
         =======
-        jac_row_idxs : ndarray, shape(2 * n + q + r,)
+        jac_row_idxs : ndarray, shape(2*n + q + r,)
             The row indices for the non-zero values in the Jacobian.
         jac_col_idxs : ndarray, shape(n,)
             The column indices for the non-zero values in the Jacobian.
@@ -240,7 +264,8 @@ class Problem(ipopt.problem):
         return (self.con_jac_rows, self.con_jac_cols)
 
     def jacobian(self, free):
-        """Returns the non-zero values of the Jacobian of the constraint function.
+        """Returns the non-zero values of the Jacobian of the constraint
+        function.
 
         Returns
         =======
@@ -263,8 +288,8 @@ class Problem(ipopt.problem):
 
         Parameters
         ==========
-        vector : ndarray, (n * N + m * M + q, )
-            The initial guess, solution, or nay other vector that is in the
+        vector : ndarray, (n*N + q*N + r, )
+            The initial guess, solution, or any other vector that is in the
             canonical form.
         axes : ndarray of AxesSubplot, shape(n + m, )
             An array of matplotlib axes to plot to.
@@ -273,6 +298,15 @@ class Problem(ipopt.problem):
         =======
         axes : ndarray of AxesSubplot
             A matplotlib axes with the state and input trajectories plotted.
+
+        Notes
+        =====
+
+        - N : number of collocation nodes
+        - n : number of unknown state trajectories
+        - m : number of input trajectories
+        - q : number of unknown input trajectories
+        - r : number of unknown parameters
 
         """
 
@@ -310,7 +344,7 @@ class Problem(ipopt.problem):
 
         Parameters
         ==========
-        vector : ndarray, (n * N + m * M + q, )
+        vector : ndarray, (n*N + q*N + r, )
             The initial guess, solution, or any other vector that is in the
             canonical form.
 
@@ -318,6 +352,14 @@ class Problem(ipopt.problem):
         =======
         axes : ndarray of AxesSubplot
             A matplotlib axes with the constraint violations plotted.
+
+        Notes
+        =====
+
+        - N : number of collocation nodes
+        - n : number of unknown state trajectories
+        - q : number of unknown input trajectories
+        - r : number of unknown parameters
 
         """
 
@@ -365,15 +407,17 @@ class ConstraintCollocator(object):
     constraints are defined from the equations of motion of the system.
 
     Notes
-    -----
+    =====
+
     - N : number of collocation nodes
-    - N - 1 + q: number of constraints
     - n : number of states
     - m : number of input trajectories
     - p : number of parameters
     - q : number of unknown input trajectories
     - r : number of unknown parameters
     - o : number of instance constraints
+    - nN + qN + r : number of free variables
+    - n(N - 1) + o : number of constraints
 
     """
 
@@ -435,7 +479,8 @@ class ConstraintCollocator(object):
         parallel : boolean, optional
             If true and openmp is installed, constraints and the Jacobian of
             the constraints will be executed across multiple threads. This is
-            only useful when the equations of motion are extremely large.
+            only useful when the equations of motion have an extremely large
+            number of operations.
 
         """
         self.eom = equations_of_motion
@@ -767,7 +812,7 @@ class ConstraintCollocator(object):
         Jacobian of the constraints."""
         idx_map = self.instance_constraints_free_index_map
 
-        num_eom_constraints = self.num_states * (self.num_collocation_nodes - 1)
+        num_eom_constraints = self.num_states*(self.num_collocation_nodes - 1)
 
         rows = []
         cols = []
@@ -956,7 +1001,7 @@ class ConstraintCollocator(object):
 
         Returns
         -------
-        jac_row_idxs : ndarray, shape(2 * n + q + r,)
+        jac_row_idxs : ndarray, shape(2*n + q + r,)
             The row indices for the non-zero values in the Jacobian.
         jac_col_idxs : ndarray, shape(n,)
             The column indices for the non-zero values in the Jacobian.
@@ -1258,13 +1303,13 @@ class ConstraintCollocator(object):
 
             Notes
             -----
-            N : number of collocation nodes
-            n : number of states
-            m : number of input trajectories
-            p : number of parameters
-            q : number of unknown input trajectories
-            r : number of unknown parameters
-            n * (N - 1) : number of constraints
+            - N : number of collocation nodes
+            - n : number of states
+            - m : number of input trajectories
+            - p : number of parameters
+            - q : number of unknown input trajectories
+            - r : number of unknown parameters
+            - n*(N - 1) : number of constraints
 
             """
             if state_values.shape[0] < 2:

--- a/opty/parameter_identification.py
+++ b/opty/parameter_identification.py
@@ -42,9 +42,9 @@ def objective_function(free, num_dis_points, num_states, dis_period,
 
     Parameters
     ----------
-    free : ndarray, shape(n * N + q,)
-        The flattened state array with n states at N time points and the q
-        free model constants.
+    free : ndarray, shape(n*N + q*N + r,)
+        The flattened state array with n states at N time points, q input
+        trajectories and N time points, and the r free model constants.
     num_dis_points : integer
         The number of model discretization points.
     num_states : integer
@@ -96,9 +96,9 @@ def objective_function_gradient(free, num_dis_points, num_states,
 
     Parameters
     ----------
-    free : ndarray, shape(N * n + q,)
-        The flattened state array with n states at N time points and the q
-        free model constants.
+    free : ndarray, shape(n*N + q*N + r,)
+        The flattened state array with n states at N time points, q input
+        trajectories and N time points, and the r free model constants.
     num_dis_points : integer
         The number of model discretization points.
     num_states : integer
@@ -111,9 +111,8 @@ def objective_function_gradient(free, num_dis_points, num_states,
 
     Returns
     -------
-    gradient : ndarray, shape(N * n + q,)
-        The gradient of the cost function with respect to the free
-        parameters.
+    gradient : ndarray, shape(n*N + q*N + r,)
+        The gradient of the cost function with respect to the free parameters.
 
     Warning
     -------

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -59,14 +59,16 @@ def f_minus_ma(mass_matrix, forcing_vector, states):
     return mass_matrix * xdot - forcing_vector
 
 
-def parse_free(free, n, r, N):
+def parse_free(free, n, q, N):
     """Parses the free parameters vector and returns it's components.
 
-    free : ndarray, shape(n * N + m * M + q)
+    Parameters
+    ----------
+    free : ndarray, shape(n*N + q*N + r)
         The free parameters of the system.
     n : integer
         The number of states.
-    r : integer
+    q : integer
         The number of free specified inputs.
     N : integer
         The number of time steps.
@@ -83,16 +85,16 @@ def parse_free(free, n, r, N):
     """
 
     len_states = n * N
-    len_specified = r * N
+    len_specified = q * N
 
     free_states = free[:len_states].reshape((n, N))
 
-    if r == 0:
+    if q == 0:
         free_specified = None
     else:
         free_specified = free[len_states:len_states + len_specified]
-        if r > 1:
-            free_specified = free_specified.reshape((r, N))
+        if q > 1:
+            free_specified = free_specified.reshape((q, N))
 
     free_constants = free[len_states + len_specified:]
 


### PR DESCRIPTION
There were inconsistencies among different functions and the theory
documentation regarding the variable names for the counts of different
sets, e.g. number of states, number of unknown inputs, etc. This patch
attempts to unify the language and add clarifications to different
docstrings.