### PR TITLE
Function to generate object and objective gradient evaluator functions

### DIFF
--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -17,7 +17,7 @@ except TypeError:  # SymPy >=1.6
                                     catch=(RuntimeError,))
 
 from .utils import (ufuncify_matrix, parse_free, _optional_plt_dep,
-                    _forward_jacobian)
+                    _forward_jacobian, sort_sympy)
 
 __all__ = ['Problem', 'ConstraintCollocator']
 
@@ -574,14 +574,6 @@ class ConstraintCollocator(object):
         """
         all_syms = set(all_syms)
         known_syms = known_syms
-
-        def sort_sympy(seq):
-            seq = list(seq)
-            try:  # symbols
-                seq.sort(key=lambda x: x.name)
-            except AttributeError:  # functions
-                seq.sort(key=lambda x: x.__class__.__name__)
-            return seq
 
         if not all_syms:  # if empty sequence
             if known_syms:

--- a/opty/tests/test_utils.py
+++ b/opty/tests/test_utils.py
@@ -45,6 +45,93 @@ def test_f_minus_ma():
     assert sym.simplify(constraint - expected) == sym.Matrix([0, 0])
 
 
+def test_create_objective_function():
+    t = sym.symbols('t')
+    x, v = sym.symbols('x, v', cls=sym.Function)
+    m, c, k = sym.symbols('m, c, k')
+    f1, f2 = sym.symbols('f1:3', cls=sym.Function)
+
+    x = x(t)
+    v = v(t)
+    f1, f2 = f1(t), f2(t)
+
+    state_symbols = [x, v]
+    input_symbols = [f2, f1]  # Should be sorted
+    unknown_symbols = [m, c, k]  # Should be sorted
+    n, q, r = len(state_symbols), len(input_symbols), len(unknown_symbols)
+    N = 20
+
+    x_vals = np.random.random(N)
+    v_vals = np.random.random(N)
+    f1_vals = np.random.random(N)
+    f2_vals = np.random.random(N)
+    m_val, c_val, k_val = np.random.random(3)
+    free = np.hstack((x_vals, v_vals, f1_vals, f2_vals, c_val, k_val, m_val))
+
+    # Test objective function based on a single state
+    obj_expr = x ** 2
+    obj, obj_grad = utils.create_objective_function(
+        obj_expr, state_symbols, input_symbols, unknown_symbols, N, 1)
+    np.testing.assert_allclose(obj(free), (x_vals ** 2).sum())
+    np.testing.assert_allclose(obj_grad(free), np.hstack((
+        2 * x_vals, np.zeros(N * (q + 1) + r))))
+
+    # Test objective function based on a single input
+    obj_expr = f1 ** 2
+    obj, obj_grad = utils.create_objective_function(
+        obj_expr, state_symbols, input_symbols, unknown_symbols, N, 1)
+    np.testing.assert_allclose(obj(free), (f1_vals ** 2).sum())
+    np.testing.assert_allclose(obj_grad(free), np.hstack((
+        np.zeros(N * n), 2 * f1_vals, np.zeros(N * 1 + r))))
+
+    # Test objective function based on a single unknown, and check sorting
+    obj_expr = m ** 2
+    obj, obj_grad = utils.create_objective_function(
+        obj_expr, state_symbols, input_symbols, unknown_symbols, N, 1)
+    np.testing.assert_allclose(obj(free), m_val ** 2)
+    np.testing.assert_allclose(obj_grad(free), np.hstack((
+        np.zeros(N * (n + q)), np.zeros(2), 2 * m_val)))
+
+    # Test objective function based on states and inputs
+    obj_expr = 1 * x ** 2 + 2 * v ** 2 + 3 * f1 ** 2 + 4 * f2 ** 2
+    obj, obj_grad = utils.create_objective_function(
+            obj_expr, state_symbols, input_symbols, unknown_symbols, N, 1)
+    np.testing.assert_allclose(
+        obj(free),
+        (x_vals ** 2).sum() + 2 * (v_vals ** 2).sum() +
+        3 * (f1_vals ** 2).sum() + 4 * (f2_vals ** 2).sum())
+    np.testing.assert_allclose(obj_grad(free), np.hstack((
+        2 * x_vals, 4 * v_vals, 6 * f1_vals, 8 * f2_vals, np.zeros(3)))
+    )
+
+    # Test objective function based on everything
+    obj_expr = (
+        1 * x ** 2 +
+        2 * v ** 2 +
+        3 * f1 ** 2 +
+        4 * f2 ** 2 +
+        5 * sym.sin(m) ** 2 +
+        6 * c ** 2 +
+        7 * k ** 2
+    )
+    try:
+        obj, obj_grad = utils.create_objective_function(
+            obj_expr, state_symbols, input_symbols, unknown_symbols, N, 1)
+    except NotImplementedError:
+        # This is a known issue, and the test is not essential.
+        pass
+    else:
+        np.testing.assert_allclose(
+            obj(free),
+            (x_vals ** 2).sum() + 2 * (v_vals ** 2).sum() +
+            3 * (f1_vals ** 2).sum() + 4 * (f2_vals ** 2).sum() +
+            5 * (np.sin(m_val) ** 2) + 6 * (c_val ** 2) + 7 * (k_val ** 2))
+        np.testing.assert_allclose(obj_grad(free), np.hstack((
+            2 * x_vals, 4 * v_vals, 6 * f1_vals, 8 * f2_vals,
+            10 * np.sin(m_val) * np.cos(m_val), 12 * c_val, 14 * k_val)))
+    
+
+
 def test_parse_free():
 
     q = 2  # two free model constants

--- a/opty/tests/test_utils.py
+++ b/opty/tests/test_utils.py
@@ -76,7 +76,7 @@ class TestCreateObjectiveFunction(object):
                                self.m_val))
 
     def test_backward_single_state(self):
-        obj_expr = sym.Integral(self.x ** 2, (self.t,))
+        obj_expr = sym.Integral(self.x ** 2, self.t)
         obj, obj_grad = utils.create_objective_function(
             obj_expr, self.state_symbols, self.input_symbols,
             self.unknown_symbols, self.N, 0.5)
@@ -87,7 +87,7 @@ class TestCreateObjectiveFunction(object):
             np.zeros(self.N * (1 + self.q) + self.r))))
 
     def test_backward_single_input(self):
-        obj_expr = sym.Integral(self.f1 ** 2, (self.t,))
+        obj_expr = sym.Integral(self.f1 ** 2, self.t)
         obj, obj_grad = utils.create_objective_function(
             obj_expr, self.state_symbols, self.input_symbols,
             self.unknown_symbols, self.N, 1)
@@ -107,8 +107,8 @@ class TestCreateObjectiveFunction(object):
 
     def test_backward_all(self):
         obj_expr = (
-            sym.Integral(self.x ** 2 + self.m ** 2, (self.t,)) +
-            sym.Integral(self.c ** 2 * self.f2 ** 2 , (self.t,)) +
+            sym.Integral(self.x ** 2 + self.m ** 2, self.t) +
+            sym.Integral(self.c ** 2 * self.f2 ** 2 , self.t) +
             sym.sin(self.k) ** 2            
         )
         obj, obj_grad = utils.create_objective_function(
@@ -131,7 +131,7 @@ class TestCreateObjectiveFunction(object):
 
     def test_no_states(self):
         free = self.free[self.n * self.N:]
-        obj_expr = sym.Integral(self.f1 ** 2, (self.t,))
+        obj_expr = sym.Integral(self.f1 ** 2, self.t)
         obj, obj_grad = utils.create_objective_function(
             obj_expr, [], self.input_symbols, self.unknown_symbols, self.N, 1)
         np.testing.assert_allclose(obj(free), (self.f1_vals[1:] ** 2).sum())
@@ -141,7 +141,7 @@ class TestCreateObjectiveFunction(object):
 
     def test_no_inputs(self):
         free = np.hstack((self.free[:self.n * self.N], self.free[-self.r:]))
-        obj_expr = sym.Integral(self.x ** 2, (self.t,))
+        obj_expr = sym.Integral(self.x ** 2, self.t)
         obj, obj_grad = utils.create_objective_function(
             obj_expr, self.state_symbols, [], self.unknown_symbols, self.N, 1)
         np.testing.assert_allclose(obj(free), (self.x_vals[1:] ** 2).sum())
@@ -151,7 +151,7 @@ class TestCreateObjectiveFunction(object):
 
     def test_no_unknowns(self):
         free = self.free[:-self.r]
-        obj_expr = sym.Integral(self.x ** 2, (self.t,))
+        obj_expr = sym.Integral(self.x ** 2, self.t)
         obj, obj_grad = utils.create_objective_function(
             obj_expr, self.state_symbols, self.input_symbols, [], self.N, 1)
         np.testing.assert_allclose(obj(free), (self.x_vals[1:] ** 2).sum())
@@ -161,8 +161,8 @@ class TestCreateObjectiveFunction(object):
 
     def test_midpoint_all(self):
         obj_expr = (
-            sym.Integral(self.x ** 2 + self.m ** 2, (self.t,)) +
-            sym.Integral(self.c ** 2 * self.f2 ** 2 , (self.t,)) +
+            sym.Integral(self.x ** 2 + self.m ** 2, self.t) +
+            sym.Integral(self.c ** 2 * self.f2 ** 2 , self.t) +
             sym.sin(self.k) ** 2            
         )
         x_mid = (self.x_vals[1:] + self.x_vals[:-1]) / 2
@@ -190,16 +190,15 @@ class TestCreateObjectiveFunction(object):
     def test_not_existing_method(self):
         with pytest.raises(NotImplementedError):
             utils.create_objective_function(
-                sym.Integral(self.x ** 2, (self.t,)), self.state_symbols,
+                sym.Integral(self.x ** 2, self.t), self.state_symbols,
                 self.input_symbols, self.unknown_symbols, self.N, 1,
                 integration_method='not_existing_method')
 
     def test_invalid_integration_limits(self):
-        with pytest.raises(Exception):
+        with pytest.raises(NotImplementedError):
             obj, obj_grad = utils.create_objective_function(
                 sym.Integral(self.x ** 2, (self.t, 0, 1)), self.state_symbols,
                 self.input_symbols, self.unknown_symbols, self.N, 1)
-            obj(self.free)
 
 
 def test_parse_free():

--- a/opty/tests/test_utils.py
+++ b/opty/tests/test_utils.py
@@ -187,6 +187,20 @@ class TestCreateObjectiveFunction(object):
             0.3 * (self.N - 1) * 2 * self.m_val
             )))
 
+    def test_not_existing_method(self):
+        with pytest.raises(NotImplementedError):
+            utils.create_objective_function(
+                sym.Integral(self.x ** 2, (self.t,)), self.state_symbols,
+                self.input_symbols, self.unknown_symbols, self.N, 1,
+                integration_method='not_existing_method')
+
+    def test_invalid_integration_limits(self):
+        with pytest.raises(Exception):
+            obj, obj_grad = utils.create_objective_function(
+                sym.Integral(self.x ** 2, (self.t, 0, 1)), self.state_symbols,
+                self.input_symbols, self.unknown_symbols, self.N, 1)
+            obj(self.free)
+
 
 def test_parse_free():
 

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -229,6 +229,16 @@ def parse_free(free, n, q, N):
     return free_states, free_specified, free_constants
 
 
+def sort_sympy(seq):
+    """Returns a sorted list of the symbols."""
+    seq = list(seq)
+    try:  # symbols
+        seq.sort(key=lambda x: x.name)
+    except AttributeError:  # functions
+        seq.sort(key=lambda x: x.__class__.__name__)
+    return seq
+
+
 _c_template = """\
 #include <math.h>
 #include "{file_prefix}_h.h"

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -306,16 +306,12 @@ def create_objective_function(
             objective_grad[n + q:], np.hstack((0, np.ones(N - 1))), True)
         def obj(free):
             states = free[:i_idx].reshape((n, N))
-            states[:, 0] = 0
             inputs = free[i_idx:r_idx].reshape((q, N))
-            inputs[:, 0] = 0
             return obj_expr_eval(states, inputs, free[r_idx:])
         
         def obj_grad(free):
             states = free[:i_idx].reshape((n, N))
-            states[:, 0] = 0
             inputs = free[i_idx:r_idx].reshape((q, N))
-            inputs[:, 0] = 0
             return np.hstack((
                 *obj_grad_time_expr_eval(states, inputs, free[r_idx:]),
                 obj_grad_param_expr_eval(states, inputs, free[r_idx:])

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -239,7 +239,8 @@ def create_objective_function(
     ----------
     objective : sympy.Expr
         The objective function to be minimized, which is a function of the
-        states and inputs.
+        states and inputs. The objective function can contain non-nested
+        indefinite integrals of time, e.g. ``Integral(f(t)**2, t)``.
     state_symbols : iterable of symbols
         The state variables.
     input_symbols : iterable of symbols

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -345,7 +345,8 @@ def create_objective_function(
             ))
 
     else:
-        raise ValueError("Invalid integration method.")
+        raise NotImplementedError(
+            f"Integration method '{integration_method}' is not implemented.")
 
     return obj, obj_grad
 

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -340,7 +340,6 @@ def create_objective_function(
             states_mid = 0.5 * (states[:, :-1] + states[:, 1:])
             inputs = free[i_idx:r_idx].reshape((q, N))
             inputs_mid = 0.5 * (inputs[:, :-1] + inputs[:, 1:])
-            print(obj_expr_eval.__doc__)
             return obj_expr_eval(states_mid, inputs_mid, free[r_idx:])
         
         def obj_grad(free):
@@ -348,7 +347,6 @@ def create_objective_function(
             states_mid = 0.5 * (states[:, :-1] + states[:, 1:])
             inputs = free[i_idx:r_idx].reshape((q, N))
             inputs_mid = 0.5 * (inputs[:, :-1] + inputs[:, 1:])
-            print(inputs_mid.shape)
             return np.hstack((
                 *obj_grad_time_expr_eval(states, inputs, free[r_idx:]),
                 obj_grad_param_expr_eval(states_mid, inputs_mid, free[r_idx:])


### PR DESCRIPTION
This PR proposes a utility function to allow one to specify an analytic expression as the objective function.
It is a relatively simple function with one major limitation, namely that one cannot use time-dependent and time-independent variables in the objective function.

Additionally, I noticed while opening this PR that #31 aims to implement a similar utility in an entirely different way. Will have to look into that one to see if it would be a better solution.