### PR TITLE
Improve constraint violation visualization

### DIFF
--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -377,7 +377,8 @@ class Problem(cyipopt.Problem):
         con_nodes = range(1, self.collocator.num_collocation_nodes)
 
         plot_inst_viols = self.collocator.instance_constraints is not None
-        fig, axes = plt.subplots(1 + plot_inst_viols)
+        fig, axes = plt.subplots(1 + plot_inst_viols, squeeze=False)
+        axes = axes.ravel()
         
         axes[0].plot(con_nodes, state_violations.T)
         axes[0].set_title('Constraint violations')

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -367,27 +367,30 @@ class Problem(cyipopt.Problem):
         - r : number of unknown parameters
 
         """
-
+        N = self.collocator.num_collocation_nodes
         con_violations = self.con(vector)
-        con_nodes = range(self.collocator.num_states,
-                          self.collocator.num_collocation_nodes + 1)
-        N = len(con_nodes)
-        fig, axes = plt.subplots(self.collocator.num_states + 1)
+        state_violations = con_violations[
+            :(N - 1) * len(self.collocator.state_symbols)]
+        instance_violations = con_violations[len(state_violations):]
+        state_violations = state_violations.reshape(
+            (len(self.collocator.state_symbols), N - 1))
+        con_nodes = range(1, self.collocator.num_collocation_nodes)
 
-        for i, (ax, symbol) in enumerate(zip(axes[:-1],
-                                             self.collocator.state_symbols)):
-            ax.plot(con_nodes, con_violations[i * N:i * N + N])
-            ax.set_ylabel(sm.latex(symbol, mode='inline'))
+        plot_inst_viols = self.collocator.instance_constraints is not None
+        fig, axes = plt.subplots(1 + plot_inst_viols)
+        
+        axes[0].plot(con_nodes, state_violations.T)
+        axes[0].set_title('Constraint violations')
+        axes[0].set_xlabel('Node Number')
+        axes[0].set_ylabel('EoM violation')
 
-        axes[0].set_title('Constraint Violations')
-        axes[-2].set_xlabel('Node Number')
-
-        left = range(len(con_violations[self.collocator.num_states * N:]))
-        axes[-1].bar(left, con_violations[self.collocator.num_states * N:],
-                     tick_label=[sm.latex(s, mode='inline')
-                                 for s in self.collocator.instance_constraints])
-        axes[-1].set_ylabel('Instance')
-        axes[-1].set_xticklabels(axes[-1].get_xticklabels(), rotation=-10)
+        if plot_inst_viols:
+            axes[-1].bar(
+                range(len(instance_violations)), instance_violations,
+                tick_label=[sm.latex(s, mode='inline')
+                            for s in self.collocator.instance_constraints])
+            axes[-1].set_ylabel('Instance')
+            axes[-1].set_xticklabels(axes[-1].get_xticklabels(), rotation=-10)
 
         return axes
 


### PR DESCRIPTION
Fixes #123 and #53

Changes
---------
Correct the slicing of the constraints_violation vector.
The constraint vector is formatted as (refer to [the creation of the constraint function](https://github.com/csu-hmc/opty/blob/6a23d17493341ad5698e61c6a2dd6e1353b47440/opty/direct_collocation.py#L886) and [the wrapper](https://github.com/csu-hmc/opty/blob/6a23d17493341ad5698e61c6a2dd6e1353b47440/opty/direct_collocation.py#L1440):
```
[con_1_2, ..., con_1_N,
con_2_2, ..., con_2_N,
...,
con_n_2, ..., con_n_N,
*instance_constraints]
```
where `con_1_2, ..., con_1_N` the constraint violation is at every node for the first discrete equation of motion.

Only create a single axis for showing the EoM violation, as they are not officially coupled to specific states. Yes, it is correct to say that most will specify the first n//2 as kinematic differential equations, but that is not required.

Only plot the constraint violations of the instance constraints if there are any instance constraints.