### PR TITLE
Implements support for variable duration solutions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,10 @@ Features
   no need to solve for the derivatives of the dependent variables.
 - Backward Euler or Midpoint integration methods.
 - Supports both trajectory optimization and parameter identification.
+- Solve fixed duration or variable duration problems.
 - Easy specification of bounds on free variables.
 - Easily specify additional "instance" constraints.
+- Efficient numerical execution of large equations of motion.
 - Automatic parallel execution using openmp if installed.
 - Built with support of sympy.physics.mechanics and PyDy in mind.
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -89,6 +89,12 @@ Example console output::
 
    EXIT: Optimal Solution Found.
 
+Single Pendulum Swing Up: Variable Duration
+===========================================
+
+.. plot:: ../examples/pendulum_swing_up_variable_duration.py
+   :include-source:
+
 Betts 2003
 ==========
 

--- a/examples/pendulum_swing_up.py
+++ b/examples/pendulum_swing_up.py
@@ -68,7 +68,7 @@ instance_constraints = (theta(1),
 prob = Problem(obj, obj_grad, eom, state_symbols, num_nodes, interval_value,
                known_parameter_map=par_map,
                instance_constraints=instance_constraints,
-               bounds={T(t): (-2.0, 2.0)})
+               bounds={T(t): (-2.0, 2.0), interval_value: (0.0, 0.5)})
 
 # Use a random positive initial guess.
 initial_guess = np.random.randn(prob.num_free)

--- a/examples/pendulum_swing_up.py
+++ b/examples/pendulum_swing_up.py
@@ -18,10 +18,11 @@ import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
 target_angle = np.pi
+duration = 10.0
 num_nodes = 500
 save_animation = False
 
-interval_value = sym.symbols('h')
+interval_value = duration / (num_nodes - 1)
 
 # Symbolic equations of motion
 I, m, g, d, t = sym.symbols('I, m, g, d, t')
@@ -41,39 +42,28 @@ par_map[m] = 1.0
 par_map[g] = 9.81
 par_map[d] = 1.0
 
-
 # Specify the objective function and it's gradient.
-def obj(free):
-    """Minimize the sum of the squares of the control torque."""
-    T = free[2 * num_nodes:]
-    return free[-1] * np.sum(T**2)
-
-
-def obj_grad(free):
-    T = free[2 * num_nodes:]
-    grad = np.zeros_like(free)
-    grad[2 * num_nodes:] = 2.0 * free[-1] * free[2 * num_nodes:]
-    grad[-1] = np.sum(T**2)
-    return grad
-
+obj_func = sym.Integral(T(t)**2, t)
+obj, obj_grad = create_objective_function(obj_func, state_symbols,
+                                          specified_symbols, tuple(),
+                                          num_nodes,
+                                          node_time_interval=interval_value)
 
 # Specify the symbolic instance constraints, i.e. initial and end
 # conditions.
-instance_constraints = (theta(1),
-                        theta(num_nodes) - target_angle,
-                        omega(1),
-                        omega(num_nodes))
+instance_constraints = (theta(0.0),
+                        theta(duration) - target_angle,
+                        omega(0.0),
+                        omega(duration))
 
 # Create an optimization problem.
 prob = Problem(obj, obj_grad, eom, state_symbols, num_nodes, interval_value,
                known_parameter_map=par_map,
                instance_constraints=instance_constraints,
-               bounds={T(t): (-2.0, 2.0), interval_value: (0.0, 0.5)})
+               bounds={T(t): (-2.0, 2.0)})
 
 # Use a random positive initial guess.
 initial_guess = np.random.randn(prob.num_free)
-initial_guess = np.zeros(prob.num_free)
-initial_guess[-1] = 0.01
 
 # Find the optimal solution.
 solution, info = prob.solve(initial_guess)
@@ -85,9 +75,7 @@ prob.plot_objective_value()
 
 # Display animation
 if not building_docs():
-    #time = np.linspace(0.0, duration, num=num_nodes)
-    interval_value = solution[-1]
-    time = np.linspace(0.0, num_nodes*solution[-1], num=num_nodes)
+    time = np.linspace(0.0, duration, num=num_nodes)
     angle = solution[:num_nodes]
 
     fig = plt.figure()

--- a/examples/pendulum_swing_up_variable_duration.py
+++ b/examples/pendulum_swing_up_variable_duration.py
@@ -59,10 +59,10 @@ def obj_grad(free):
 
 # Specify the symbolic instance constraints, i.e. initial and end conditions
 # using node numbers 1 to N.
-instance_constraints = (theta(1),
-                        theta(num_nodes) - target_angle,
-                        omega(1),
-                        omega(num_nodes))
+instance_constraints = (theta(1*h),
+                        theta(num_nodes*h) - target_angle,
+                        omega(1*h),
+                        omega(num_nodes*h))
 
 # Create an optimization problem.
 prob = Problem(obj, obj_grad, eom, state_symbols, num_nodes, h,

--- a/examples/pendulum_swing_up_variable_duration.py
+++ b/examples/pendulum_swing_up_variable_duration.py
@@ -1,0 +1,122 @@
+"""This solves the simple pendulum swing up problem presented here:
+
+http://hmc.csuohio.edu/resources/human-motion-seminar-jan-23-2014
+
+A simple pendulum is controlled by a torque at its joint. The goal is to
+swing the pendulum from its rest equilibrium to a target angle by minimizing
+the energy used to do so.
+
+"""
+
+from collections import OrderedDict
+
+import numpy as np
+import sympy as sym
+from opty.direct_collocation import Problem
+from opty.utils import building_docs, create_objective_function
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+
+target_angle = np.pi
+num_nodes = 500
+save_animation = False
+
+interval_value = sym.symbols('h')
+
+# Symbolic equations of motion
+I, m, g, d, t = sym.symbols('I, m, g, d, t')
+theta, omega, T = sym.symbols('theta, omega, T', cls=sym.Function)
+
+state_symbols = (theta(t), omega(t))
+constant_symbols = (I, m, g, d)
+specified_symbols = (T(t),)
+
+eom = sym.Matrix([theta(t).diff() - omega(t),
+                  I * omega(t).diff() + m * g * d * sym.sin(theta(t)) - T(t)])
+
+# Specify the known system parameters.
+par_map = OrderedDict()
+par_map[I] = 1.0
+par_map[m] = 1.0
+par_map[g] = 9.81
+par_map[d] = 1.0
+
+
+# Specify the objective function and it's gradient.
+def obj(free):
+    """Minimize the sum of the squares of the control torque."""
+    T = free[2 * num_nodes:]
+    return free[-1] * np.sum(T**2)
+
+
+def obj_grad(free):
+    T = free[2 * num_nodes:]
+    grad = np.zeros_like(free)
+    grad[2 * num_nodes:] = 2.0 * free[-1] * free[2 * num_nodes:]
+    grad[-1] = np.sum(T**2)
+    return grad
+
+
+# Specify the symbolic instance constraints, i.e. initial and end
+# conditions.
+instance_constraints = (theta(1),
+                        theta(num_nodes) - target_angle,
+                        omega(1),
+                        omega(num_nodes))
+
+# Create an optimization problem.
+prob = Problem(obj, obj_grad, eom, state_symbols, num_nodes, interval_value,
+               known_parameter_map=par_map,
+               instance_constraints=instance_constraints,
+               bounds={T(t): (-2.0, 2.0), interval_value: (0.0, 0.5)})
+
+# Use a random positive initial guess.
+initial_guess = np.random.randn(prob.num_free)
+initial_guess = np.zeros(prob.num_free)
+initial_guess[-1] = 0.01
+
+# Find the optimal solution.
+solution, info = prob.solve(initial_guess)
+
+# Make some plots
+prob.plot_trajectories(solution)
+prob.plot_constraint_violations(solution)
+prob.plot_objective_value()
+
+# Display animation
+if not building_docs():
+    #time = np.linspace(0.0, duration, num=num_nodes)
+    interval_value = solution[-1]
+    time = np.linspace(0.0, num_nodes*solution[-1], num=num_nodes)
+    angle = solution[:num_nodes]
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, aspect='equal', autoscale_on=False, xlim=(-2, 2),
+                         ylim=(-2, 2))
+    ax.grid()
+
+    line, = ax.plot([], [], 'o-', lw=2)
+    time_template = 'time = {:0.1f}s'
+    time_text = ax.text(0.05, 0.9, '', transform=ax.transAxes)
+
+    def init():
+        line.set_data([], [])
+        time_text.set_text('')
+        return line, time_text
+
+    def animate(i):
+        x = [0, par_map[d] * np.sin(angle[i])]
+        y = [0, -par_map[d] * np.cos(angle[i])]
+
+        line.set_data(x, y)
+        time_text.set_text(time_template.format(i * interval_value))
+        return line, time_text
+
+    ani = animation.FuncAnimation(fig, animate, np.arange(1, len(time)),
+                                  interval=25, blit=True, init_func=init)
+
+    if save_animation:
+        ani.save('pendulum_swing_up.mp4', writer='ffmpeg',
+                 fps=1 / interval_value)
+
+plt.show()

--- a/examples/pendulum_swing_up_variable_duration.py
+++ b/examples/pendulum_swing_up_variable_duration.py
@@ -2,9 +2,12 @@
 
 http://hmc.csuohio.edu/resources/human-motion-seminar-jan-23-2014
 
-A simple pendulum is controlled by a torque at its joint. The goal is to
-swing the pendulum from its rest equilibrium to a target angle by minimizing
-the energy used to do so.
+A simple pendulum is controlled by a torque at its joint. The goal is to swing
+the pendulum from its rest equilibrium to a target angle by minimizing the
+energy used to do so in a minimal amount of time.
+
+Solves the same problem as in ``pendulum_swing_up.py`` but with a variable
+total duration.
 
 """
 
@@ -13,7 +16,7 @@ from collections import OrderedDict
 import numpy as np
 import sympy as sym
 from opty.direct_collocation import Problem
-from opty.utils import building_docs, create_objective_function
+from opty.utils import building_docs
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
@@ -21,22 +24,19 @@ target_angle = np.pi
 num_nodes = 500
 save_animation = False
 
-interval_value = sym.symbols('h')
-
 # Symbolic equations of motion
-I, m, g, d, t = sym.symbols('I, m, g, d, t')
+m, g, d, t, h = sym.symbols('m, g, d, t, h')
 theta, omega, T = sym.symbols('theta, omega, T', cls=sym.Function)
 
 state_symbols = (theta(t), omega(t))
-constant_symbols = (I, m, g, d)
+constant_symbols = (m, g, d)
 specified_symbols = (T(t),)
 
 eom = sym.Matrix([theta(t).diff() - omega(t),
-                  I * omega(t).diff() + m * g * d * sym.sin(theta(t)) - T(t)])
+                  m*d**2*omega(t).diff() + m*g*d*sym.sin(theta(t)) - T(t)])
 
 # Specify the known system parameters.
 par_map = OrderedDict()
-par_map[I] = 1.0
 par_map[m] = 1.0
 par_map[g] = 9.81
 par_map[d] = 1.0
@@ -46,7 +46,7 @@ par_map[d] = 1.0
 def obj(free):
     """Minimize the sum of the squares of the control torque."""
     T = free[2 * num_nodes:]
-    return free[-1] * np.sum(T**2)
+    return free[-1]*np.sum(T**2)
 
 
 def obj_grad(free):
@@ -57,23 +57,22 @@ def obj_grad(free):
     return grad
 
 
-# Specify the symbolic instance constraints, i.e. initial and end
-# conditions.
+# Specify the symbolic instance constraints, i.e. initial and end conditions
+# using node numbers 1 to N.
 instance_constraints = (theta(1),
                         theta(num_nodes) - target_angle,
                         omega(1),
                         omega(num_nodes))
 
 # Create an optimization problem.
-prob = Problem(obj, obj_grad, eom, state_symbols, num_nodes, interval_value,
+prob = Problem(obj, obj_grad, eom, state_symbols, num_nodes, h,
                known_parameter_map=par_map,
                instance_constraints=instance_constraints,
-               bounds={T(t): (-2.0, 2.0), interval_value: (0.0, 0.5)})
+               time_symbol=t,
+               bounds={T(t): (-2.0, 2.0), h: (0.0, 0.5)})
 
-# Use a random positive initial guess.
-initial_guess = np.random.randn(prob.num_free)
+# Use a zero as an initial guess.
 initial_guess = np.zeros(prob.num_free)
-initial_guess[-1] = 0.01
 
 # Find the optimal solution.
 solution, info = prob.solve(initial_guess)
@@ -85,7 +84,6 @@ prob.plot_objective_value()
 
 # Display animation
 if not building_docs():
-    #time = np.linspace(0.0, duration, num=num_nodes)
     interval_value = solution[-1]
     time = np.linspace(0.0, num_nodes*solution[-1], num=num_nodes)
     angle = solution[:num_nodes]
@@ -109,14 +107,14 @@ if not building_docs():
         y = [0, -par_map[d] * np.cos(angle[i])]
 
         line.set_data(x, y)
-        time_text.set_text(time_template.format(i * interval_value))
+        time_text.set_text(time_template.format(i*interval_value))
         return line, time_text
 
     ani = animation.FuncAnimation(fig, animate, np.arange(1, len(time)),
                                   interval=25, blit=True, init_func=init)
 
     if save_animation:
-        ani.save('pendulum_swing_up.mp4', writer='ffmpeg',
+        ani.save('pendulum_swing_up_variable_duration.mp4', writer='ffmpeg',
                  fps=1 / interval_value)
 
 plt.show()

--- a/examples/pendulum_swing_up_variable_duration.py
+++ b/examples/pendulum_swing_up_variable_duration.py
@@ -58,11 +58,11 @@ def obj_grad(free):
 
 
 # Specify the symbolic instance constraints, i.e. initial and end conditions
-# using node numbers 1 to N.
-instance_constraints = (theta(1*h),
-                        theta(num_nodes*h) - target_angle,
-                        omega(1*h),
-                        omega(num_nodes*h))
+# using node numbers 0 to N - 1
+instance_constraints = (theta(0*h),
+                        theta((num_nodes - 1)*h) - target_angle,
+                        omega(0*h),
+                        omega((num_nodes - 1)*h))
 
 # Create an optimization problem.
 prob = Problem(obj, obj_grad, eom, state_symbols, num_nodes, h,

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -369,6 +369,8 @@ class Problem(cyipopt.Problem):
         axes[0].set_title('State Trajectories')
         axes[self.collocator.num_states].set_title('Input Trajectories')
 
+        fig.tight_layout()
+
         return axes
 
     @_optional_plt_dep
@@ -422,6 +424,8 @@ class Problem(cyipopt.Problem):
                             for s in self.collocator.instance_constraints])
             axes[-1].set_ylabel('Instance')
             axes[-1].set_xticklabels(axes[-1].get_xticklabels(), rotation=-10)
+
+        fig.tight_layout()
 
         return axes
 

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -334,15 +334,18 @@ class Problem(cyipopt.Problem):
 
         """
 
-        state_traj, input_traj, constants = parse_free(
-            vector, self.collocator.num_states,
-            self.collocator.num_unknown_input_trajectories,
-            self.collocator.num_collocation_nodes)
-
         if self.collocator._variable_duration:
-            node_time_interval = constants[-1]
-            constants = constants[:-1]
+            state_traj, input_traj, constants, node_time_interval = parse_free(
+                vector, self.collocator.num_states,
+                self.collocator.num_unknown_input_trajectories,
+                self.collocator.num_collocation_nodes,
+                variable_duration=self.collocator._variable_duration)
         else:
+            state_traj, input_traj, constants = parse_free(
+                vector, self.collocator.num_states,
+                self.collocator.num_unknown_input_trajectories,
+                self.collocator.num_collocation_nodes,
+                variable_duration=self.collocator._variable_duration)
             node_time_interval = self.collocator.node_time_interval
 
         time = np.linspace(0,
@@ -1477,16 +1480,18 @@ class ConstraintCollocator(object):
 
         def constraints(free):
 
-            free_states, free_specified, free_constants = parse_free(
-                free, self.num_states, self.num_unknown_input_trajectories,
-                self.num_collocation_nodes)
-
-            # TODO : Probably best to modify parse free, but that may require
-            # backwards incompatible change.
             if self._variable_duration:
-                time_interval = free_constants[-1]
-                free_constants = free_constants[:-1]
+                (free_states, free_specified, free_constants,
+                 time_interval) = parse_free(
+                     free, self.num_states,
+                     self.num_unknown_input_trajectories,
+                     self.num_collocation_nodes,
+                     variable_duration=self._variable_duration)
             else:
+                free_states, free_specified, free_constants = parse_free(
+                    free, self.num_states, self.num_unknown_input_trajectories,
+                    self.num_collocation_nodes,
+                    variable_duration=self._variable_duration)
                 time_interval = self.node_time_interval
 
             all_specified = self._merge_fixed_free(self.input_trajectories,

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -180,6 +180,13 @@ class Problem(cyipopt.Problem):
                     idx = num_non_par_nodes + i
                     lb[idx] = bounds[0]
                     ub[idx] = bounds[1]
+                elif (self.collocator._variable_duration and
+                      var == self.collocator.time_interval_symbol):
+                    lb[-1] = bounds[0]
+                    ub[-1] = bounds[1]
+                else:
+                    msg = 'Bound variable {} not present in free variables.'
+                    raise ValueError(msg.format(var))
 
         self.lower_bound = lb
         self.upper_bound = ub

--- a/opty/tests/test_direct_collocation.py
+++ b/opty/tests/test_direct_collocation.py
@@ -1161,12 +1161,13 @@ class TestConstraintCollocatorVariableDuration():
 
         # Additional node equality contraints.
         theta, omega = sym.symbols('theta, omega', cls=sym.Function)
-        # If it is variable duration then use values 1 to N to specify instance
-        # constraints instead of time.
-        instance_constraints = (theta(1*h),  # theta(t0)
-                                theta(self.num_nodes*h) - sym.pi,  # theta(tf)
-                                omega(1*h),  # omega(t0)
-                                omega(self.num_nodes*h))  # omega(tf)
+        # If it is variable duration then use values 0 to N - 1 to specify
+        # instance constraints instead of time.
+        t0, tf = 0*h, (self.num_nodes - 1)*h
+        instance_constraints = (theta(t0),
+                                theta(tf) - sym.pi,
+                                omega(t0),
+                                omega(tf))
 
         self.collocator = ConstraintCollocator(
             equations_of_motion=self.eom,
@@ -1239,10 +1240,10 @@ class TestConstraintCollocatorVariableDuration():
 
         theta, omega = sym.symbols('theta, omega', cls=sym.Function)
 
-        expected = set((theta(1*self.interval_symbol),
-                        theta(self.num_nodes*self.interval_symbol),
-                        omega(1*self.interval_symbol),
-                        omega(self.num_nodes*self.interval_symbol)))
+        expected = set((theta(0*self.interval_symbol),
+                        theta((self.num_nodes - 1)*self.interval_symbol),
+                        omega(0*self.interval_symbol),
+                        omega((self.num_nodes - 1)*self.interval_symbol)))
 
         assert self.collocator.instance_constraint_function_atoms == expected
 
@@ -1254,10 +1255,10 @@ class TestConstraintCollocatorVariableDuration():
         self.collocator._find_closest_free_index()
 
         expected = {
-            theta(1*self.interval_symbol): 0,
-            theta(self.num_nodes*self.interval_symbol): 3,
-            omega(1*self.interval_symbol): 4,
-            omega(self.num_nodes*self.interval_symbol): 7,
+            theta(0*self.interval_symbol): 0,
+            theta((self.num_nodes - 1)*self.interval_symbol): 3,
+            omega(0*self.interval_symbol): 4,
+            omega((self.num_nodes - 1)*self.interval_symbol): 7,
         }
 
         assert self.collocator.instance_constraints_free_index_map == expected

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -34,7 +34,8 @@ def _forward_jacobian(expr, wrt):
     def add_to_cache(node):
         if node in expr_to_replacement_cache:
             replacement_symbol = expr_to_replacement_cache[node]
-            return replacement_symbol, replacement_to_reduced_expr_cache[replacement_symbol]
+            return (replacement_symbol,
+                    replacement_to_reduced_expr_cache[replacement_symbol])
         elif node in replacement_to_reduced_expr_cache:
             return node, replacement_to_reduced_expr_cache[node]
         elif isinstance(node, sm.Tuple):
@@ -88,7 +89,8 @@ def _forward_jacobian(expr, wrt):
     finish = timer()
     logging.info(f'Completed in {finish - start:.2f}s')
 
-    reduced_matrix = sm.ImmutableDenseMatrix(reduced_exprs).xreplace(expr_to_replacement_cache)
+    reduced_matrix = sm.ImmutableDenseMatrix(reduced_exprs).xreplace(
+        expr_to_replacement_cache)
     replacements = list(replacement_to_reduced_expr_cache.items())
 
     partial_derivative_mapping = {}
@@ -96,7 +98,8 @@ def _forward_jacobian(expr, wrt):
     for i, wrt_symbol in enumerate(wrt.args[2]):
         absolute_derivative = [sm.S.Zero] * len(wrt)
         absolute_derivative[i] = sm.S.One
-        absolute_derivative_mapping[wrt_symbol] = sm.ImmutableDenseMatrix([absolute_derivative])
+        absolute_derivative_mapping[wrt_symbol] = sm.ImmutableDenseMatrix(
+            [absolute_derivative])
 
     logging.info('Differentiating expression nodes...')
     start = timer()
@@ -105,11 +108,16 @@ def _forward_jacobian(expr, wrt):
         free_symbols = subexpr.free_symbols
         absolute_derivative = zeros
         for free_symbol in free_symbols:
-            replacement_symbol, partial_derivative = add_to_cache(subexpr.diff(free_symbol))
-            absolute_derivative += partial_derivative * absolute_derivative_mapping.get(free_symbol, zeros)
-        absolute_derivative_mapping[symbol] = sm.ImmutableDenseMatrix([[add_to_cache(a)[0] for a in absolute_derivative]])
+            replacement_symbol, partial_derivative = add_to_cache(
+                subexpr.diff(free_symbol))
+            absolute_derivative += (
+                partial_derivative *
+                absolute_derivative_mapping.get(free_symbol, zeros))
+        absolute_derivative_mapping[symbol] = sm.ImmutableDenseMatrix(
+            [[add_to_cache(a)[0] for a in absolute_derivative]])
 
-    replaced_jacobian = sm.ImmutableDenseMatrix.vstack(*[absolute_derivative_mapping[e] for e in reduced_matrix])
+    replaced_jacobian = sm.ImmutableDenseMatrix.vstack(*[
+        absolute_derivative_mapping[e] for e in reduced_matrix])
     finish = timer()
     logging.info(f'Completed in {finish - start:.2f}s')
 
@@ -121,7 +129,8 @@ def _forward_jacobian(expr, wrt):
         entry = stack.pop()
         if entry in required_replacement_symbols or entry in wrt:
             continue
-        children = list(replacement_to_reduced_expr_cache.get(entry, entry).free_symbols)
+        children = list(
+            replacement_to_reduced_expr_cache.get(entry, entry).free_symbols)
         for child in children:
             if child not in required_replacement_symbols and child not in wrt:
                 stack.append(child)
@@ -131,7 +140,8 @@ def _forward_jacobian(expr, wrt):
 
     required_replacements_dense = {
         replacement_symbol: replaced_subexpr
-        for replacement_symbol, replaced_subexpr in replacement_to_reduced_expr_cache.items()
+        for replacement_symbol, replaced_subexpr in
+        replacement_to_reduced_expr_cache.items()
         if replacement_symbol in required_replacement_symbols
     }
 
@@ -143,14 +153,16 @@ def _forward_jacobian(expr, wrt):
     required_replacements = {}
     unrequired_replacements = {}
     for replacement_symbol, replaced_subexpr in required_replacements_dense.items():
-        if isinstance(replaced_subexpr, sm.Symbol) or counter[replacement_symbol] == 1:
+        if (isinstance(replaced_subexpr, sm.Symbol) or
+            counter[replacement_symbol] == 1):
             unrequired_replacements[replacement_symbol] = replaced_subexpr.xreplace(unrequired_replacements)
         else:
             required_replacements[replacement_symbol] = replaced_subexpr.xreplace(unrequired_replacements)
     finish = timer()
     logging.info(f'Completed in {finish - start:.2f}s')
 
-    return (list(required_replacements.items()), [replaced_jacobian.xreplace(unrequired_replacements)])
+    return (list(required_replacements.items()),
+            [replaced_jacobian.xreplace(unrequired_replacements)])
 
 
 def building_docs():
@@ -188,7 +200,7 @@ def f_minus_ma(mass_matrix, forcing_vector, states):
     return mass_matrix * xdot - forcing_vector
 
 
-def parse_free(free, n, q, N):
+def parse_free(free, n, q, N, variable_duration=False):
     """Parses the free parameters vector and returns it's components.
 
     Parameters
@@ -201,6 +213,9 @@ def parse_free(free, n, q, N):
         The number of free specified inputs.
     N : integer
         The number of time steps.
+    variable_duration : boolean, optional
+        If True, the last value in ``free`` is the node time interval and it
+        will be returned.
 
     Returns
     -------
@@ -210,6 +225,9 @@ def parse_free(free, n, q, N):
         The array of q specified inputs through N time steps.
     constant_values : ndarray, shape(r,)
         The array of r constants.
+    time_interval : float
+        The time between collocation nodes. Only returned if
+        ``variable_duration`` is ``True``.
 
     """
 
@@ -225,9 +243,13 @@ def parse_free(free, n, q, N):
         if q > 1:
             free_specified = free_specified.reshape((q, N))
 
-    free_constants = free[len_states + len_specified:]
-
-    return free_states, free_specified, free_constants
+    if variable_duration:
+        free_time_interval = free[-1]
+        free_constants = free[len_states + len_specified:-1]
+        return free_states, free_specified, free_constants, free_time_interval
+    else:
+        free_constants = free[len_states + len_specified:]
+        return free_states, free_specified, free_constants
 
 
 def create_objective_function(

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -193,7 +193,7 @@ def parse_free(free, n, q, N):
 
     Parameters
     ----------
-    free : ndarray, shape(n*N + q*N + r)
+    free : ndarray, shape(n*N + q*N + r + s)
         The free parameters of the system.
     n : integer
         The number of states.


### PR DESCRIPTION
Fixes #19

This PR allows a user to pass in a symbol as the node interval value instead of a float and then specify instance constraints in terms of node index instead of time. This adds the node interval value as a free optimization variable (as the last element) and the resulting constraint equations and Jacobian takes into account the variable interval. I demonstrate it on the pendulum swing up problem.

- [x] Allow user to set bounds on the node time interval.
- [x] Update `parse_free` to deal with having h as the last term.
- [x] Make example problem for variable duration.
- [x] Show how to use this in the documentation examples.