### PR TITLE
Handle variable h

### DIFF
--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -151,7 +151,7 @@ class Problem(cyipopt.Problem):
             ``{x(t): (-1.0, 5.0)}``.
 
         """
-        # needed for plot_constraint_violations method below
+        # needed for the plot_constraint_violations method below
         self.zeit = node_time_interval
 
         self.collocator = ConstraintCollocator(
@@ -533,21 +533,20 @@ class Problem(cyipopt.Problem):
         axes[0].set_ylabel('EoM violation')
 
         # reduce the instance constrtaints to 2 significant digits.
-        # if variable h is used, sue the result for h in the time.
+        # if variable h is used, use the result for h in the time.
         instance_constr_plot = []
         a_before = ''
+        a_before_before = ''
         for exp1 in self.collocator.instance_constraints:
             for a in sm.preorder_traversal(exp1):
-                print('a:', a, type(a))
-#                if a == self.zeit:
-#                    print('treffer', a)
-                if (isinstance(a_before, sm.Integer) or isinstance(a_before, sm.Float)) and (a == self.zeit):
+                if ((isinstance(a_before, sm.Integer) or
+                        isinstance(a_before, sm.Float)) and (a == self.zeit)):
                     a_before = float(a_before)
-                    print('a_before:', a_before)
-#                    exp1 = exp1.subs(a_before, sm.Symbol(''))
-                    exp1 = exp1.subs(a, sm.Float(round(vector[-1], 5)))
+                    hilfs = a_before * vector[-1]
+                    exp1 = exp1.subs(a_before_before, sm.Float(round(hilfs, 2)))
                 elif isinstance(a_before, sm.Float) and (a != self.zeit):
                     exp1 = exp1.subs(a_before, round(a_before, 2))
+                a_before_before = a_before
                 a_before = a
             instance_constr_plot.append(exp1)
 

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -452,6 +452,7 @@ class Problem(cyipopt.Problem):
             If the uses gives at least two axis, the method will tell the user
             how many are needed, unless the correct amount is given.
 
+
         Notes
         =====
 
@@ -461,13 +462,18 @@ class Problem(cyipopt.Problem):
         - r : number of unknown parameters
         - s : number of unknown time intervals
 
+        If node_time_interval is a sympy.Symbol, the times in the instance
+        constraints should be given as alpha * h, where alpha is an integer
+        or a float and h is the name of the node_time_interval symbol. This
+        will ensure that the time is given correctly in the plot.
+
         """
 
         bars_per_plot = None
         rotation = -45
 
         # find the number of bars per plot, so the bars per plot are arroximately
-        # the same on each bar.
+        # the same on each plot.
         hilfs = []
         len_constr = len(self.collocator.instance_constraints)
         for i in range(6, 11):
@@ -532,7 +538,8 @@ class Problem(cyipopt.Problem):
         axes[0].set_xlabel('Node Number')
         axes[0].set_ylabel('EoM violation')
 
-        # reduce the instance constrtaints to 2 significant digits.
+        # reduce the instance constrtaints to 2 digits after the decimal point.
+        # give the time in tha variables with 2 digits after the decimal point.
         # if variable h is used, use the result for h in the time.
         instance_constr_plot = []
         a_before = ''

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -151,8 +151,6 @@ class Problem(cyipopt.Problem):
             ``{x(t): (-1.0, 5.0)}``.
 
         """
-        # needed for the plot_constraint_violations method below
-        self.zeit = node_time_interval
 
         self.collocator = ConstraintCollocator(
             equations_of_motion, state_symbols, num_collocation_nodes,
@@ -462,11 +460,6 @@ class Problem(cyipopt.Problem):
         - r : number of unknown parameters
         - s : number of unknown time intervals
 
-        If node_time_interval is a sympy.Symbol, the times in the instance
-        constraints should be given as alpha * h, where alpha is an integer
-        or a float and h is the name of the node_time_interval symbol. This
-        will ensure that the time is given correctly in the plot.
-
         """
 
         bars_per_plot = None
@@ -547,11 +540,13 @@ class Problem(cyipopt.Problem):
         for exp1 in self.collocator.instance_constraints:
             for a in sm.preorder_traversal(exp1):
                 if ((isinstance(a_before, sm.Integer) or
-                        isinstance(a_before, sm.Float)) and (a == self.zeit)):
+                        isinstance(a_before, sm.Float)) and
+                        (a == self.collocator.node_time_interval)):
                     a_before = float(a_before)
                     hilfs = a_before * vector[-1]
                     exp1 = exp1.subs(a_before_before, sm.Float(round(hilfs, 2)))
-                elif isinstance(a_before, sm.Float) and (a != self.zeit):
+                elif (isinstance(a_before, sm.Float) and
+                (a != self.collocator.node_time_interval)):
                     exp1 = exp1.subs(a_before, round(a_before, 2))
                 a_before_before = a_before
                 a_before = a

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -533,18 +533,19 @@ class Problem(cyipopt.Problem):
         axes[0].set_ylabel('EoM violation')
 
         # reduce the instance constrtaints to 2 significant digits.
+        # if variable h is used, sue the result for h in the time.
         instance_constr_plot = []
         a_before = ''
         for exp1 in self.collocator.instance_constraints:
             for a in sm.preorder_traversal(exp1):
-#                print('a:', a, type(a))
+                print('a:', a, type(a))
 #                if a == self.zeit:
 #                    print('treffer', a)
-                if isinstance(a_before, sm.Integer) and (a == self.zeit):
+                if (isinstance(a_before, sm.Integer) or isinstance(a_before, sm.Float)) and (a == self.zeit):
                     a_before = float(a_before)
-#                    print('a_before:', a_before)
-                    exp1 = exp1.subs(a_before, sm.Symbol(''))
-                    exp1 = exp1.subs(a, round(sm.Float(a_before/(a_before-1) * vector[-1]), 4))
+                    print('a_before:', a_before)
+#                    exp1 = exp1.subs(a_before, sm.Symbol(''))
+                    exp1 = exp1.subs(a, sm.Float(round(vector[-1], 5)))
                 elif isinstance(a_before, sm.Float) and (a != self.zeit):
                     exp1 = exp1.subs(a_before, round(a_before, 2))
                 a_before = a

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -151,6 +151,8 @@ class Problem(cyipopt.Problem):
             ``{x(t): (-1.0, 5.0)}``.
 
         """
+        # needed for plot_constraint_violations method below
+        self.zeit = node_time_interval
 
         self.collocator = ConstraintCollocator(
             equations_of_motion, state_symbols, num_collocation_nodes,
@@ -532,10 +534,20 @@ class Problem(cyipopt.Problem):
 
         # reduce the instance constrtaints to 2 significant digits.
         instance_constr_plot = []
+        a_before = ''
         for exp1 in self.collocator.instance_constraints:
             for a in sm.preorder_traversal(exp1):
-                if isinstance(a, sm.Float):
-                    exp1 = exp1.subs(a, round(a, 2))
+#                print('a:', a, type(a))
+#                if a == self.zeit:
+#                    print('treffer', a)
+                if isinstance(a_before, sm.Integer) and (a == self.zeit):
+                    a_before = float(a_before)
+#                    print('a_before:', a_before)
+                    exp1 = exp1.subs(a_before, sm.Symbol(''))
+                    exp1 = exp1.subs(a, round(sm.Float(a_before/(a_before-1) * vector[-1]), 4))
+                elif isinstance(a_before, sm.Float) and (a != self.zeit):
+                    exp1 = exp1.subs(a_before, round(a_before, 2))
+                a_before = a
             instance_constr_plot.append(exp1)
 
         if plot_inst_viols:


### PR DESCRIPTION
I case of variable h its value is used in the plots. e.g. if, say. num_nodes = 251 and $h_{optimal} = 0.1$ and duration =(num_nodes - 1) * h it will print, say, $x_0(25.0)$ instead of $x_0(250h)$
The times in the instance constraints should be given as t * h, where t is an integer or a float to ensure proper printing.
t * h / 2.0 will also work, but r * h / 2 will not always work. In case it does not work the 'old' way is given.
It will be rounded to max. two digits after the decimal point. (I assume in sympy the 'mul objects' are handled differently for floats and integers, but I did not study this, just trial and error)