### PR TITLE
make plot_trajectories work if no input trajectories are given

### DIFF
--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -418,7 +418,8 @@ class Problem(cyipopt.Problem):
             ax.set_ylabel(sm.latex(symbol, mode='inline'))
         ax.set_xlabel('Time')
         axes[0].set_title('State Trajectories')
-        axes[self.collocator.num_states].set_title('Input Trajectories')
+        if self.collocator.num_input_trajectories > 0:
+            axes[self.collocator.num_states].set_title('Input Trajectories')
 
         return axes
 


### PR DESCRIPTION
plot_trajectories tries to put the title _Input Trajectories_ on a non existing axis if no input trajectories are present.
I check whether they are present.