### PR TITLE
docstrings changed for solve to match opty

### DIFF
--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -202,7 +202,7 @@ class Problem(cyipopt.Problem):
     def solve(self, free):
         """
 
-        **solve**(x)
+        **solve(x)**
 
         Returns the optimal solution and an info dictionary.
 

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -197,6 +197,65 @@ class Problem(cyipopt.Problem):
 
         self.obj_value = []
 
+    # this is added only to correct the docstring, which is a bit different with
+    # opty compared to cyipopt.
+    def solve(self, free):
+        """
+        **solve**(x)
+
+        Returns the optimal solution and an info dictionary.
+
+        Solves the posed optimization problem starting at point x.
+
+        Parameters:
+
+            x (array-like, shape(n*N + q*N + r + s, ))
+
+                Initial guess.
+
+        Returns:
+
+            x (array, shape(n*N + q*N + r + s, ))
+
+                optimal solution.
+
+            info (dictionary)
+
+                x: ndarray, shape(n*N + q*N + r + s, )
+
+                    optimal solution
+
+                g: ndarray, shape(n*(N-1) + o, )
+
+                    constraints at the optimal solution
+
+                obj_val: float
+
+                    objective value at optimal solution
+
+                mult_g: ndarray, shape(n*(N-1) + o, )
+
+                    final values of the constraint multipliers
+
+                mult_x_L: ndarray, shape(n*N + q*N + r + s, )
+
+                    bound multipliers at the solution
+
+                mult_x_U: ndarray, shape(n*N + q*N + r + s, )
+
+                    bound multipliers at the solution
+
+                status: integer
+
+                    gives the status of the algorithm
+
+                status_msg: string
+
+                    gives the status of the algorithm as a message
+
+        """
+        return super().solve(free)
+
     def _generate_bound_arrays(self):
         lb = -self.INF * np.ones(self.num_free)
         ub = self.INF * np.ones(self.num_free)

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -201,6 +201,7 @@ class Problem(cyipopt.Problem):
     # opty compared to cyipopt.
     def solve(self, free):
         """
+
         **solve**(x)
 
         Returns the optimal solution and an info dictionary.
@@ -254,6 +255,7 @@ class Problem(cyipopt.Problem):
                     gives the status of the algorithm as a message
 
         """
+
         return super().solve(free)
 
     def _generate_bound_arrays(self):

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -197,8 +197,6 @@ class Problem(cyipopt.Problem):
 
         self.obj_value = []
 
-    # this is added only to correct the docstring, which is a bit different with
-    # opty compared to cyipopt.
     def solve(self, free, lagrange=[], zl=[], zu=[]):
         """Returns the optimal solution and an info dictionary.
 
@@ -243,7 +241,7 @@ class Problem(cyipopt.Problem):
 
         """
 
-        return super().solve(free, lagrange=[], zl=[], zu=[])
+        return super().solve(free, lagrange=lagrange, zl=zl, zu=zu)
 
     def _generate_bound_arrays(self):
         lb = -self.INF * np.ones(self.num_free)

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -199,7 +199,7 @@ class Problem(cyipopt.Problem):
 
     # this is added only to correct the docstring, which is a bit different with
     # opty compared to cyipopt.
-    def solve(self, free):
+    def solve(self, free, lagrange=[], zl=[], zu=[]):
         """Returns the optimal solution and an info dictionary.
 
         Solves the posed optimization problem starting at point x.
@@ -243,7 +243,7 @@ class Problem(cyipopt.Problem):
 
         """
 
-        return super().solve(free)
+        return super().solve(free, lagrange=[], zl=[], zu=[])
 
     def _generate_bound_arrays(self):
         lb = -self.INF * np.ones(self.num_free)

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -200,59 +200,46 @@ class Problem(cyipopt.Problem):
     # this is added only to correct the docstring, which is a bit different with
     # opty compared to cyipopt.
     def solve(self, free):
-        """
-
-        **solve(x)**
-
-        Returns the optimal solution and an info dictionary.
+        """Returns the optimal solution and an info dictionary.
 
         Solves the posed optimization problem starting at point x.
 
-        Parameters:
+        Parameters
+        ----------
+        x : array-like, shape(n*N + q*N + r + s, )
+            Initial guess.
 
-            x (array-like, shape(n*N + q*N + r + s, ))
+        lagrange : array-like, shape(n*(N-1) + o, ), optional (default=[])
+            Initial values for the constraint multipliers (only if warm start option is chosen).
 
-                Initial guess.
+        zl : array-like, shape(n*N + q*N + r + s, ), optional (default=[])
+            Initial values for the multipliers for lower variable bounds (only if warm start option is chosen).
 
-        Returns:
+        zu : array-like, shape(n*N + q*N + r + s, ), optional (default=[])
+            Initial values for the multipliers for upper variable bounds (only if warm start option is chosen).
 
-            x (array, shape(n*N + q*N + r + s, ))
+        Returns
+        -------
+        x : :py:class:`numpy.ndarray`, shape `(n*N + q*N + r + s, )`
+            Optimal solution.
+        info: :py:class:`dict` with the following entries
 
-                optimal solution.
-
-            info (dictionary)
-
-                x: ndarray, shape(n*N + q*N + r + s, )
-
-                    optimal solution
-
-                g: ndarray, shape(n*(N-1) + o, )
-
-                    constraints at the optimal solution
-
-                obj_val: float
-
-                    objective value at optimal solution
-
-                mult_g: ndarray, shape(n*(N-1) + o, )
-
-                    final values of the constraint multipliers
-
-                mult_x_L: ndarray, shape(n*N + q*N + r + s, )
-
-                    bound multipliers at the solution
-
-                mult_x_U: ndarray, shape(n*N + q*N + r + s, )
-
-                    bound multipliers at the solution
-
-                status: integer
-
-                    gives the status of the algorithm
-
-                status_msg: string
-
-                    gives the status of the algorithm as a message
+            ``x``: :py:class:`numpy.ndarray`, shape `(n*N + q*N + r + s, )`
+                optimal solution
+            ``g``: :py:class:`numpy.ndarray`, shape `(n*(N-1) + o, )`
+                constraints at the optimal solution
+            ``obj_val``: :py:class:`float`
+                objective value at optimal solution
+            ``mult_g``: :py:class:`numpy.ndarray`, shape `(n*(N-1) + o, )`
+                final values of the constraint multipliers
+            ``mult_x_L``: :py:class:`numpy.ndarray`, shape `(n*N + q*N + r + s, )`
+                bound multipliers at the solution
+            ``mult_x_U``: :py:class:`numpy.ndarray`, shape `(n*N + q*N + r + s, )`
+                bound multipliers at the solution
+            ``status``: :py:class:`int`
+                gives the status of the algorithm
+            ``status_msg``: :py:class:`str`
+                gives the status of the algorithm as a message
 
         """
 


### PR DESCRIPTION
Added a function solve to direct_collocation as suggested by JM above to get docstrings which better match opty.
In my tests in ran fine.
1. I do not know how the check the visual appearance of what I did, so I do not know, how it will look in the opty documentation
2. It seems to me, that the output of info['g'] has shape (n*(N-1) + o, ) not (n*N + o, ). This is only based on numerical trials, no understanding behind it. 