### PR TITLE
AEs only

### DIFF
--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -157,11 +157,11 @@ class Problem(cyipopt.Problem):
 
         """
 
-        if equations_of_motion.has(sm.Derivative) == False:
-            raise ValueError('No time derivatives are present.' +
-                ' The equations of motion must be ordinary ' +
-                'differential equations (ODEs) or ' +
-                'differential algebraic equations (DAEs).')
+    #    if equations_of_motion.has(sm.Derivative) == False:
+    #        raise ValueError('No time derivatives are present.' +
+    #            ' The equations of motion must be ordinary ' +
+    #            'differential equations (ODEs) or ' +
+    #            'differential algebraic equations (DAEs).')
 
         self.collocator = ConstraintCollocator(
             equations_of_motion, state_symbols, num_collocation_nodes,

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -157,12 +157,6 @@ class Problem(cyipopt.Problem):
 
         """
 
-    #    if equations_of_motion.has(sm.Derivative) == False:
-    #        raise ValueError('No time derivatives are present.' +
-    #            ' The equations of motion must be ordinary ' +
-    #            'differential equations (ODEs) or ' +
-    #            'differential algebraic equations (DAEs).')
-
         self.collocator = ConstraintCollocator(
             equations_of_motion, state_symbols, num_collocation_nodes,
             node_time_interval, known_parameter_map, known_trajectory_map,


### PR DESCRIPTION
opty can solve equations of motion which only consist of algebraic equations. I simply removed the lines which test for differential equations.
Surely this is not the main goal of opty!
Still it might be useful to have this option, say, to get th steady state behaviour of a set of differential equations - in any case it does not hurt to have the option, without stressing it,or even pointing it out in the documentation.