### PR TITLE
make attributes of ConstraintCollocator read-only

### DIFF
--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -1023,8 +1023,12 @@ class ConstraintCollocator(object):
         return self._num_known_input_trajectories
 
     @property
-    def integration_method(self.elf):
+    def integration_method(self):
         return self._integration_method
+
+    @property
+    def current_discrete_specified_symbols(self):
+        return self._current_discrete_specified_symbols
 
     @integration_method.setter
     def integration_method(self, method):

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -693,8 +693,6 @@ class ConstraintCollocator(object):
     num_input_trajectories : int
         The number of input trajectories = len(input_trajectories).
     num_known_input_trajectories : int
-        The number of known input trajectories = len(known_input_trajectories).
-    num_known_input_trajectories : int
         The number of known trajectories = len(known_trajectory_symbols).
     num_parameters : int
         The number of parameters = len(parameters).

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -1023,7 +1023,7 @@ class ConstraintCollocator(object):
         return self._num_known_input_trajectories
 
     @property
-    def integration_method(self):
+    def integration_method(self.elf):
         return self._integration_method
 
     @integration_method.setter
@@ -1202,7 +1202,7 @@ class ConstraintCollocator(object):
             tuple([sm.Symbol(f.__class__.__name__ + 'n', real=True)
                    for f in self._unknown_input_trajectories])
 
-        self._current_specified_symbols = (
+        self._current_discrete_specified_symbols = (
             self._current_known_discrete_specified_symbols +
             self._current_unknown_discrete_specified_symbols)
         self._next_discrete_specified_symbols = (
@@ -1227,7 +1227,7 @@ class ConstraintCollocator(object):
         xp = self._previous_discrete_state_symbols
         xi = self._current_discrete_state_symbols
         xn = self._next_discrete_state_symbols
-        ui = self._current_specified_symbols
+        ui = self._current_discrete_specified_symbols
         un = self._next_discrete_specified_symbols
 
         h = self._time_interval_symbol
@@ -1398,7 +1398,7 @@ class ConstraintCollocator(object):
         xi_syms = self._current_discrete_state_symbols
         xp_syms = self._previous_discrete_state_symbols
         xn_syms = self._next_discrete_state_symbols
-        si_syms = self._current_specified_symbols
+        si_syms = self._current_discrete_specified_symbols
         sn_syms = self._next_discrete_specified_symbols
         h_sym = self._time_interval_symbol
         constant_syms = self._known_parameters + self._unknown_parameters
@@ -1730,7 +1730,7 @@ class ConstraintCollocator(object):
         xi_syms = self._current_discrete_state_symbols
         xp_syms = self._previous_discrete_state_symbols
         xn_syms = self._next_discrete_state_symbols
-        si_syms = self._current_specified_symbols
+        si_syms = self._current_discrete_specified_symbols
         sn_syms = self._next_discrete_specified_symbols
         ui_syms = self._current_unknown_discrete_specified_symbols
         un_syms = self._next_unknown_discrete_specified_symbols

--- a/opty/tests/test_direct_collocation.py
+++ b/opty/tests/test_direct_collocation.py
@@ -1687,3 +1687,120 @@ def test_prob_parse_free():
     np.testing.assert_allclose(controls, controlsu)
     np.testing.assert_allclose(constants, constantsu)
     np.testing.assert_allclose(timeu, times)
+
+def test_attributes_read_only():
+    """
+    Test to ensure the ConstraintCollocator attributes are read-only.
+    """
+
+    # random optimization problem
+    x1, x2, x3 = mech.dynamicsymbols('x1 x2 x3')
+    ux1, ux2, ux3 = mech.dynamicsymbols('ux1 ux2 ux3')
+    u1, u2, u3 = mech.dynamicsymbols('u1 u2 u3')
+    a1, a2, a3, a4, a5, a6 = sym.symbols('a1 a2 a3 a4 a5 a6')
+    h = sym.symbols('h')
+
+    t = mech.dynamicsymbols._t
+    eom = sym.Matrix([
+        -x1.diff(t) + ux1 + a3,
+        -x2.diff(t) + ux2 + a5,
+        -x3.diff(t) + ux3,
+        -ux1.diff(t) + a6*x1 + a5*u1,
+        -ux2.diff(t) + a4*x2 + a3*u2,
+        -ux3.diff(t) + a2*x3 + a1*u3,
+    ])
+
+    # Set up the Optimization Problem
+
+    state_symbols = [x1, x2, x3, ux1, ux2, ux3]
+
+    num_nodes = 11
+    h = sym.symbols('h')
+
+    # Specify the known symbols.
+    par_map = {}
+    par_map[a2] = 1.0
+    par_map[a4] = 2.0
+    par_map[a6] = 3.0
+
+    duration = (num_nodes - 1)*h
+    t0, tf = 0.0, duration
+    interval_value = h
+
+    # Set up the instance constraints, the bounds and Problem.
+
+    instance_constraints = (
+        x1.func(t0) - 1,
+        x2.func(t0),
+        x3.func(t0),
+        x1.func(tf) - 2,
+    )
+
+    def obj(free):
+        return free[-1]
+
+    def obj_grad(free):
+        grad = np.zeros_like(free)
+        grad[-1] = 1.0
+        return grad
+
+    limit_torque = 100.0
+    bounds = {
+        u1: (-limit_torque, limit_torque),
+        u3: (-limit_torque, limit_torque),
+        h: (0.0, np.inf),
+    }
+
+    prob = Problem(
+        obj,
+        obj_grad,
+        eom,
+        state_symbols,
+        num_nodes,
+        interval_value,
+        time_symbol=t,
+        known_parameter_map=par_map,
+        instance_constraints=instance_constraints,
+        bounds=bounds,
+        integration_method='midpoint',
+    )
+    # Test if all these attributes are read-only
+    for XX in [
+        'current_discrete_state_symbols',
+        'current_known_discrete_specified_symbols',
+        'current_unknown_discrete_specified_symbols',
+        'discrete_eom',
+        'eom',
+        'input_trajectories',
+        'instance_constraints',
+        'known_input_trajectories',
+        'known_parameters',
+        'known_parameter_map',
+        'known_trajectory_map',
+        'next_known_discrete_specified_symbols',
+        'next_discrete_state_symbols',
+        'next_unknown_discrete_specified_symbols',
+        'node_time_interval',
+        'num_collocation_nodes',
+        'num_constraints',
+        'num_free',
+        'num_input_trajectories',
+        'num_known_input_trajectories',
+        'num_parameters',
+        'num_states',
+        'num_unknown_input_trajectories',
+        'num_unknown_parameters',
+        'parameters',
+        'parallel',
+        'previous_discrete_state_symbols',
+        'show_compile_output',
+        'state_derivative_symbols',
+        'state_symbols',
+        'time_symbol',
+        'tmp_dir',
+        'unknown_input_trajectories',
+        'unknown_parameters',
+        ]:
+        with raises(AttributeError):
+            setattr(prob.collocator, XX, 5)
+

--- a/opty/tests/test_direct_collocation.py
+++ b/opty/tests/test_direct_collocation.py
@@ -186,7 +186,7 @@ class TestConstraintCollocator():
 
         xi, vi, xp, vp, xn, vn, fi, fn = self.discrete_symbols
 
-        assert self.collocator._check_known_trajectoriesprevious_discrete_state_symbols == (xp, vp)
+        assert self.collocator._previous_discrete_state_symbols == (xp, vp)
         assert self.collocator._current_discrete_state_symbols == (xi, vi)
         assert self.collocator._next_discrete_state_symbols == (xn, vn)
 
@@ -951,7 +951,7 @@ class TestConstraintCollocatorInstanceConstraints():
                     omega(0.0): 4,
                     omega(0.03): 7}
 
-        assert self.collocator.instance_constraints_free_index_map == expected
+        assert self.collocator._instance_constraints_free_index_map == expected
 
     def test_lambdify_instance_constraints(self):
 
@@ -1273,7 +1273,7 @@ class TestConstraintCollocatorVariableDuration():
             omega((self._num_nodes - 1)*self.interval_symbol): 7,
         }
 
-        assert self.collocator.instance_constraints_free_index_map == expected
+        assert self.collocator._instance_constraints_free_index_map == expected
 
     def test_lambdify_instance_constraints(self):
 

--- a/opty/tests/test_direct_collocation.py
+++ b/opty/tests/test_direct_collocation.py
@@ -308,7 +308,7 @@ class TestConstraintCollocator():
         # Make sure the parameters are in the correct order.
         constant_values = \
             np.array([self.constant_values[self.constant_symbols.index(c)]
-                      for c in self.collocator._gen_multi_arg_con_func()])
+                      for c in self.collocator._gen_multi_arg_con_func])
 
         # TODO : Once there are more than one specified, they will need to
         # be put in the correct order too.

--- a/opty/tests/test_direct_collocation.py
+++ b/opty/tests/test_direct_collocation.py
@@ -61,7 +61,7 @@ def test_pendulum():
         bounds={T(t): (-2.0, 2.0)},
         show_compile_output=True)
 
-    assert prob.collocator.num_instance_constraints == 4
+    assert prob.collocator._num_instance_constraints == 4
 
 
 def test_Problem():
@@ -100,7 +100,7 @@ def test_Problem():
                                0.5, INF, 1.0])
     np.testing.assert_allclose(prob.upper_bound, expected_upper)
 
-    assert prob.collocator.num_instance_constraints == 0
+    assert prob.collocator._num_instance_constraints == 0
 
 
 class TestConstraintCollocator():
@@ -143,11 +143,11 @@ class TestConstraintCollocator():
 
     def test_init(self):
 
-        assert self.collocator.state_symbols == self.state_symbols
-        assert self.collocator.state_derivative_symbols == \
+        assert self.collocator._state_symbols == self.state_symbols
+        assert self.collocator._state_derivative_symbols == \
             tuple([s.diff() for s in self.state_symbols])
-        assert self.collocator.num_states == 2
-        assert self.collocator.num_collocation_nodes == 4
+        assert self.collocator._num_states == 2
+        assert self.collocator._num_collocation_nodes == 4
 
     def test_integration_method(self):
         with raises(ValueError):
@@ -161,11 +161,11 @@ class TestConstraintCollocator():
 
         m, c, k = self.constant_symbols
 
-        assert self.collocator.known_parameters == (m, c)
-        assert self.collocator.num_known_parameters == 2
+        assert self.collocator._known_parameters == (m, c)
+        assert self.collocator._num_known_parameters == 2
 
-        assert self.collocator.unknown_parameters == (k,)
-        assert self.collocator.num_unknown_parameters == 1
+        assert self.collocator._unknown_parameters == (k,)
+        assert self.collocator._num_unknown_parameters == 1
 
     def test_sort_trajectories(self):
 
@@ -173,12 +173,12 @@ class TestConstraintCollocator():
 
         self.collocator._sort_trajectories()
 
-        assert self.collocator.known_input_trajectories == \
+        assert self.collocator._known_input_trajectories == \
             self.specified_symbols
-        assert self.collocator.num_known_input_trajectories == 1
+        assert self.collocator._num_known_input_trajectories == 1
 
-        assert self.collocator.unknown_input_trajectories == tuple()
-        assert self.collocator.num_unknown_input_trajectories == 0
+        assert self.collocator._unknown_input_trajectories == tuple()
+        assert self.collocator._num_unknown_input_trajectories == 0
 
     def test_discrete_symbols(self):
 
@@ -186,25 +186,25 @@ class TestConstraintCollocator():
 
         xi, vi, xp, vp, xn, vn, fi, fn = self.discrete_symbols
 
-        assert self.collocator.previous_discrete_state_symbols == (xp, vp)
-        assert self.collocator.current_discrete_state_symbols == (xi, vi)
-        assert self.collocator.next_discrete_state_symbols == (xn, vn)
+        assert self.collocator._check_known_trajectoriesprevious_discrete_state_symbols == (xp, vp)
+        assert self.collocator._current_discrete_state_symbols == (xi, vi)
+        assert self.collocator._next_discrete_state_symbols == (xn, vn)
 
-        assert self.collocator.current_discrete_specified_symbols == (fi, )
-        assert self.collocator.next_discrete_specified_symbols == (fn, )
+        assert self.collocator._current_discrete_specified_symbols == (fi, )
+        assert self.collocator._next_discrete_specified_symbols == (fn, )
 
     def test_discretize_eom_backward_euler(self):
 
         m, c, k = self.constant_symbols
         xi, vi, xp, vp, xn, vn, fi, fn = self.discrete_symbols
-        h = self.collocator.time_interval_symbol
+        h = self.collocator._time_interval_symbol
 
         expected = sym.Matrix([(xi - xp) / h - vi,
                                m * (vi - vp) / h + c * vi + k * xi - fi])
 
         self.collocator._discretize_eom()
 
-        zero = sym.simplify(self.collocator.discrete_eom - expected)
+        zero = sym.simplify(self.collocator._discrete_eom - expected)
 
         assert zero == sym.Matrix([0, 0])
 
@@ -213,7 +213,7 @@ class TestConstraintCollocator():
         m, c, k = self.constant_symbols
         xi, vi, xp, vp, xn, vn, fi, fn = self.discrete_symbols
 
-        h = self.collocator.time_interval_symbol
+        h = self.collocator._time_interval_symbol
 
         expected = sym.Matrix([(xn - xi) / h - (vi + vn) / 2,
                                m * (vn - vi) / h + c * (vi + vn) / 2 +
@@ -222,7 +222,7 @@ class TestConstraintCollocator():
         self.collocator.integration_method = 'midpoint'
         self.collocator._discretize_eom()
 
-        zero = sym.simplify(self.collocator.discrete_eom - expected)
+        zero = sym.simplify(self.collocator._discrete_eom - expected)
 
         assert zero == sym.Matrix([0, 0])
 
@@ -233,7 +233,7 @@ class TestConstraintCollocator():
         # Make sure the parameters are in the correct order.
         constant_values = \
             np.array([self.constant_values[self.constant_symbols.index(c)]
-                      for c in self.collocator.parameters])
+                      for c in self.collocator._parameters])
 
         # TODO : Once there are more than one specified, they will need to
         # be put in the correct order too.
@@ -270,7 +270,7 @@ class TestConstraintCollocator():
         # Make sure the parameters are in the correct order.
         constant_values = \
             np.array([self.constant_values[self.constant_symbols.index(c)]
-                      for c in self.collocator.parameters])
+                      for c in self.collocator._parameters])
 
         # TODO : Once there are more than one specified, they will need to
         # be put in the correct order too.
@@ -308,7 +308,7 @@ class TestConstraintCollocator():
         # Make sure the parameters are in the correct order.
         constant_values = \
             np.array([self.constant_values[self.constant_symbols.index(c)]
-                      for c in self.collocator.parameters])
+                      for c in self.collocator._gen_multi_arg_con_funcparameters])
 
         # TODO : Once there are more than one specified, they will need to
         # be put in the correct order too.
@@ -351,7 +351,7 @@ class TestConstraintCollocator():
         # Make sure the parameters are in the correct order.
         constant_values = \
             np.array([self.constant_values[self.constant_symbols.index(c)]
-                      for c in self.collocator.parameters])
+                      for c in self.collocator._parameters])
 
         # TODO : Once there are more than one specified, they will need to
         # be put in the correct order too.
@@ -493,10 +493,10 @@ class TestConstraintCollocatorUnknownTrajectories():
 
     def test_init(self):
 
-        assert self.collocator.state_symbols == self.state_symbols
-        assert self.collocator.state_derivative_symbols == \
+        assert self.collocator._state_symbols == self.state_symbols
+        assert self.collocator._state_derivative_symbols == \
             tuple([s.diff() for s in self.state_symbols])
-        assert self.collocator.num_states == 2
+        assert self.collocator._num_states == 2
 
     def test_sort_parameters(self):
 
@@ -506,11 +506,11 @@ class TestConstraintCollocatorUnknownTrajectories():
 
         m, c = self.constant_symbols
 
-        assert self.collocator.known_parameters == (m,)
-        assert self.collocator.num_known_parameters == 1
+        assert self.collocator._known_parameters == (m,)
+        assert self.collocator._num_known_parameters == 1
 
-        assert self.collocator.unknown_parameters == (c,)
-        assert self.collocator.num_unknown_parameters == 1
+        assert self.collocator._unknown_parameters == (c,)
+        assert self.collocator._num_unknown_parameters == 1
 
     def test_sort_trajectories(self):
 
@@ -520,11 +520,11 @@ class TestConstraintCollocatorUnknownTrajectories():
 
         f, k = self.specified_symbols
 
-        assert self.collocator.known_input_trajectories == (f,)
-        assert self.collocator.num_known_input_trajectories == 1
+        assert self.collocator._known_input_trajectories == (f,)
+        assert self.collocator._num_known_input_trajectories == 1
 
-        assert self.collocator.unknown_input_trajectories == (k,)
-        assert self.collocator.num_unknown_input_trajectories == 1
+        assert self.collocator._unknown_input_trajectories == (k,)
+        assert self.collocator._num_unknown_input_trajectories == 1
 
     def test_discrete_symbols(self):
 
@@ -532,10 +532,10 @@ class TestConstraintCollocatorUnknownTrajectories():
 
         xi, vi, xp, vp, fi, ki = self.discrete_symbols
 
-        assert self.collocator.current_discrete_state_symbols == (xi, vi)
-        assert self.collocator.previous_discrete_state_symbols == (xp, vp)
+        assert self.collocator._current_discrete_state_symbols == (xi, vi)
+        assert self.collocator._previous_discrete_state_symbols == (xp, vp)
         # The following should be in order of known and unknown.
-        assert self.collocator.current_discrete_specified_symbols == (fi, ki)
+        assert self.collocator._current_discrete_specified_symbols == (fi, ki)
 
     def test_discretize_eom(self):
 
@@ -877,30 +877,30 @@ class TestConstraintCollocatorInstanceConstraints():
 
     def test_init(self):
 
-        assert self.collocator.state_symbols == self.state_symbols
-        assert self.collocator.state_derivative_symbols == \
+        assert self.collocator._state_symbols == self.state_symbols
+        assert self.collocator._state_derivative_symbols == \
             tuple([s.diff() for s in self.state_symbols])
-        assert self.collocator.num_states == 2
+        assert self.collocator._num_states == 2
 
     def test_sort_parameters(self):
 
         self.collocator._sort_parameters()
 
-        assert self.collocator.known_parameters == self.constant_symbols
-        assert self.collocator.num_known_parameters == 4
+        assert self.collocator._known_parameters == self.constant_symbols
+        assert self.collocator._num_known_parameters == 4
 
-        assert self.collocator.unknown_parameters == tuple()
-        assert self.collocator.num_unknown_parameters == 0
+        assert self.collocator._unknown_parameters == tuple()
+        assert self.collocator._num_unknown_parameters == 0
 
     def test_sort_trajectories(self):
 
         self.collocator._sort_trajectories()
 
-        assert self.collocator.known_input_trajectories == tuple()
-        assert self.collocator.num_known_input_trajectories == 0
+        assert self.collocator._known_input_trajectories == tuple()
+        assert self.collocator._num_known_input_trajectories == 0
 
-        assert self.collocator.unknown_input_trajectories == self.specified_symbols
-        assert self.collocator.num_unknown_input_trajectories == 1
+        assert self.collocator._unknown_input_trajectories == self.specified_symbols
+        assert self.collocator._num_unknown_input_trajectories == 1
 
     def test_discrete_symbols(self):
 
@@ -908,11 +908,11 @@ class TestConstraintCollocatorInstanceConstraints():
 
         thetai, omegai, thetap, omegap, Ti = self.discrete_symbols
 
-        assert self.collocator.current_discrete_state_symbols == (thetai,
+        assert self.collocator._current_discrete_state_symbols == (thetai,
                                                                   omegai)
-        assert self.collocator.previous_discrete_state_symbols == (thetap,
+        assert self.collocator._previous_discrete_state_symbols == (thetap,
                                                                    omegap)
-        assert self.collocator.current_discrete_specified_symbols == (Ti,)
+        assert self.collocator._current_discrete_specified_symbols == (Ti,)
 
     def test_discretize_eom(self):
 
@@ -1143,7 +1143,7 @@ class TestConstraintCollocatorVariableDuration():
         theta, omega, T = [f(t) for f in sym.symbols('theta, omega, T',
                                                      cls=sym.Function)]
 
-        self.num_nodes = 4
+        self._num_nodes = 4
         self.state_symbols = (theta, omega)
         self.constant_symbols = (m, g, d)
         self.specified_symbols = (T,)
@@ -1175,7 +1175,7 @@ class TestConstraintCollocatorVariableDuration():
         theta, omega = sym.symbols('theta, omega', cls=sym.Function)
         # If it is variable duration then use values 0 to N - 1 to specify
         # instance constraints instead of time.
-        t0, tf = 0*h, (self.num_nodes - 1)*h
+        t0, tf = 0*h, (self._num_nodes - 1)*h
         instance_constraints = (theta(t0),
                                 theta(tf) - sym.pi,
                                 omega(t0),
@@ -1184,7 +1184,7 @@ class TestConstraintCollocatorVariableDuration():
         self.collocator = ConstraintCollocator(
             equations_of_motion=self.eom,
             state_symbols=self.state_symbols,
-            num_collocation_nodes=self.num_nodes,
+            num_collocation_nodes=self._num_nodes,
             node_time_interval=self.interval_symbol,
             known_parameter_map=par_map,
             instance_constraints=instance_constraints,
@@ -1192,31 +1192,31 @@ class TestConstraintCollocatorVariableDuration():
 
     def test_init(self):
 
-        assert self.collocator.state_symbols == self.state_symbols
-        assert (self.collocator.state_derivative_symbols ==
+        assert self.collocator._state_symbols == self.state_symbols
+        assert (self.collocator._state_derivative_symbols ==
                 tuple([s.diff() for s in self.state_symbols]))
-        assert self.collocator.num_states == 2
+        assert self.collocator._num_states == 2
 
     def test_sort_parameters(self):
 
         self.collocator._sort_parameters()
 
-        assert self.collocator.known_parameters == self.constant_symbols
-        assert self.collocator.num_known_parameters == 3
+        assert self.collocator._known_parameters == self.constant_symbols
+        assert self.collocator._num_known_parameters == 3
 
-        assert self.collocator.unknown_parameters == tuple()
-        assert self.collocator.num_unknown_parameters == 0
+        assert self.collocator._unknown_parameters == tuple()
+        assert self.collocator._num_unknown_parameters == 0
 
     def test_sort_trajectories(self):
 
         self.collocator._sort_trajectories()
 
-        assert self.collocator.known_input_trajectories == tuple()
-        assert self.collocator.num_known_input_trajectories == 0
+        assert self.collocator._known_input_trajectories == tuple()
+        assert self.collocator._num_known_input_trajectories == 0
 
-        assert (self.collocator.unknown_input_trajectories ==
+        assert (self.collocator._unknown_input_trajectories ==
                 self.specified_symbols)
-        assert self.collocator.num_unknown_input_trajectories == 1
+        assert self.collocator._num_unknown_input_trajectories == 1
 
     def test_discrete_symbols(self):
 
@@ -1224,11 +1224,11 @@ class TestConstraintCollocatorVariableDuration():
 
         thetai, omegai, thetap, omegap, Ti = self.discrete_symbols
 
-        assert self.collocator.current_discrete_state_symbols == (thetai,
+        assert self.collocator._current_discrete_state_symbols == (thetai,
                                                                   omegai)
-        assert self.collocator.previous_discrete_state_symbols == (thetap,
+        assert self.collocator._previous_discrete_state_symbols == (thetap,
                                                                    omegap)
-        assert self.collocator.current_discrete_specified_symbols == (Ti,)
+        assert self.collocator._current_discrete_specified_symbols == (Ti,)
 
     def test_discretize_eom(self):
 
@@ -1253,9 +1253,9 @@ class TestConstraintCollocatorVariableDuration():
         theta, omega = sym.symbols('theta, omega', cls=sym.Function)
 
         expected = set((theta(0*self.interval_symbol),
-                        theta((self.num_nodes - 1)*self.interval_symbol),
+                        theta((self._num_nodes - 1)*self.interval_symbol),
                         omega(0*self.interval_symbol),
-                        omega((self.num_nodes - 1)*self.interval_symbol)))
+                        omega((self._num_nodes - 1)*self.interval_symbol)))
 
         assert self.collocator.instance_constraint_function_atoms == expected
 
@@ -1268,9 +1268,9 @@ class TestConstraintCollocatorVariableDuration():
 
         expected = {
             theta(0*self.interval_symbol): 0,
-            theta((self.num_nodes - 1)*self.interval_symbol): 3,
+            theta((self._num_nodes - 1)*self.interval_symbol): 3,
             omega(0*self.interval_symbol): 4,
-            omega((self.num_nodes - 1)*self.interval_symbol): 7,
+            omega((self._num_nodes - 1)*self.interval_symbol): 7,
         }
 
         assert self.collocator.instance_constraints_free_index_map == expected

--- a/opty/tests/test_direct_collocation.py
+++ b/opty/tests/test_direct_collocation.py
@@ -308,7 +308,7 @@ class TestConstraintCollocator():
         # Make sure the parameters are in the correct order.
         constant_values = \
             np.array([self.constant_values[self.constant_symbols.index(c)]
-                      for c in self.collocator._gen_multi_arg_con_funcparameters])
+                      for c in self.collocator._gen_multi_arg_con_func()])
 
         # TODO : Once there are more than one specified, they will need to
         # be put in the correct order too.

--- a/opty/tests/test_direct_collocation.py
+++ b/opty/tests/test_direct_collocation.py
@@ -308,7 +308,7 @@ class TestConstraintCollocator():
         # Make sure the parameters are in the correct order.
         constant_values = \
             np.array([self.constant_values[self.constant_symbols.index(c)]
-                      for c in self.collocator._gen_multi_arg_con_func])
+                      for c in self.collocator._parameters])
 
         # TODO : Once there are more than one specified, they will need to
         # be put in the correct order too.


### PR DESCRIPTION
I tried to make the attributes of ConstraintCollocator to be read-only, as changing them likely will break opty.
The one I did not mess around with was integration_method as it issues an error anyway if a non-valid method is set.
I also added a test function.

NB: num_free is also an attribute of Problem. As it is often used like this: initial_guess = np.zeros(prob.num_free) I left it as it is.
