### PR TITLE
raise ValueError if duplicate state symbols are present. Fixes #317

### DIFF
--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -867,6 +867,12 @@ class ConstraintCollocator(object):
             self.time_symbol = me.dynamicsymbols._t
 
         self.state_symbols = tuple(state_symbols)
+        if len(self.state_symbols) != len(set(self.state_symbols)):
+            raise ValueError('State symbols must be unique.')
+        if len(self.state_symbols) != self.eom.shape[0]:
+            raise ValueError('The number of states must match the number of '
+                             'equations of motion.')
+
         self.state_derivative_symbols = tuple([s.diff(self.time_symbol) for
                                                s in state_symbols])
         self.num_states = len(self.state_symbols)

--- a/opty/tests/test_direct_collocation.py
+++ b/opty/tests/test_direct_collocation.py
@@ -1746,3 +1746,71 @@ def test_one_eom_only():
 
     length = (2*1 + 1 + 0 + 0) * (1*(num_nodes-1)) + 2
     assert prob.jacobian(initial_guess).shape == (length,)
+
+def test_duplicate_state_symbols():
+    """Test for duplicate state symbols and for number of state_symbols is
+    equal to the number of of eoms"""
+
+    x, ux, z = mech.dynamicsymbols('x, ux, z')
+    t = mech.dynamicsymbols._t
+    m = sym.symbols('m')
+    F = mech.dynamicsymbols('F')
+
+    eom = sym.Matrix([
+        -x.diff(t) + ux,
+        -ux.diff(t) + F/m,
+        ])
+
+    par_map = {m: 1.0}
+
+    num_nodes = 76
+
+    t0, tf = 0.0, 1.0
+    interval_value = tf/(num_nodes - 1)
+
+    def obj(free):
+        Fx = free[2*num_nodes:3*num_nodes]
+        return interval_value*np.sum(Fx**2)
+
+    def obj_grad(free):
+        grad = np.zeros_like(free)
+        l1 = 2*num_nodes
+        l2 = 3*num_nodes
+        grad[l1: l2] = 2.0*free[l1:l2]*interval_value
+        return grad
+
+    instance_constraints = (
+        x.func(t0),
+        ux.func(t0),
+        x.func(tf) - 1.0,
+        ux.func(tf),
+    )
+
+     # Test for duplicate state symbols
+    state_symbols = (x, ux, x)
+    with raises(ValueError):
+        prob = Problem(
+            obj,
+            obj_grad,
+            eom,
+            state_symbols,
+            num_nodes,
+            interval_value,
+            known_parameter_map=par_map,
+            instance_constraints=instance_constraints,
+        )
+
+    # Test that No of state_symbols is equal to the No of eoms
+    state_symbols = (x, ux, z)
+    with raises(ValueError):
+        prob = Problem(
+            obj,
+            obj_grad,
+            eom,
+            state_symbols,
+            num_nodes,
+            interval_value,
+            known_parameter_map=par_map,
+            instance_constraints=instance_constraints,
+        )
+


### PR DESCRIPTION
It raises a ValueError if there are either duplicate state symbols, or the number of state symbols does not match the number of eoms. Should fix #317