### PR TITLE
examples-gallery now has three subdirectories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,11 +158,12 @@ Next download the opty source files and install with::
 Usage
 =====
 
-There are several examples available in the ``examples`` and
-``examples-gallery`` directories. The optimal torque to swing up a pendulum
-with minimal energy can be run with::
+There are several examples available in the ``examples`` directory and the
+``examples-gallery/beginner``, ``examples-gallery/intermediate`` and
+``examples-gallery/advanced``directories. The optimal torque to swing up a
+pendulum with minimal energy can be run with::
 
-   $ python examples-gallery/plot_pendulum_swing_up_fixed_duration.py
+   $ python examples-gallery/beginner/plot_pendulum_swing_up_fixed_duration.py
 
 Failed Compilation
 ------------------


### PR DESCRIPTION
I think the path given to the example was not fully correct anymore - at least if I understood correctly.