### PR TITLE
Raise minimum dependency versions to match those in Ubuntu 22.04 (Jammy).

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - name: Checkout Opty
         uses: actions/checkout@v4
+      # NOTE : I use mamba only on Windows because conda started to fail to
+      # solve Windows builds and was timing out in CI. See
+      # https://github.com/csu-hmc/opty/pull/363 for more info.
       - name: Setup Conda environment
         if: runner.os == 'Windows'
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
           environment-file: opty-dev-env.yml
+          conda-remove-defaults: "true"
       - name: Install openmp and pydy
         if: runner.os == 'Linux'
         run: |
@@ -53,7 +54,7 @@ jobs:
           pytest --cov=opty opty/
       - name: Install Opty and test import
         run: |
-          python -m pip install .
+          python -m pip install --no-deps --no-build-isolation .
           conda list
           python -c "import opty"
       - name: Run an example

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,35 +27,36 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          environment-file: opty-dev-env.yml
           conda-remove-defaults: "true"
+          environment-file: opty-dev-env.yml
+          mamba-version: "*"
+          python-version: ${{ matrix.python-version }}
       - name: Install openmp and pydy
         if: runner.os == 'Linux'
         run: |
-          conda list
-          conda install libgomp pydy
+          mamba list
+          mamba install libgomp pydy
       - name: Install openmp and pydy
         if: runner.os == 'macOS'
         run: |
-          conda list
-          conda install llvm-openmp pydy
+          mamba list
+          mamba install llvm-openmp pydy
       # llvm-openmp fails to install because it is incompatible with ipopt, but
       # openmp "installs", nonetheless the openmp example fails to compile.
       - name: Install openmp and pydy
         if: runner.os == 'Windows'
         run: |
-          conda list
-          conda install openmp pydy
+          mamba list
+          mamba install openmp pydy
       - name: Test with pytest
         run: |
-          conda list
+          mamba list
           pytest --cov=opty opty/
       - name: Install Opty and test import
         run: |
           python -m pip install --no-deps --no-build-isolation .
-          conda list
+          mamba list
           python -c "import opty"
       - name: Run an example
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,31 +32,31 @@ jobs:
           environment-file: opty-dev-env.yml
           mamba-version: "*"
           python-version: ${{ matrix.python-version }}
-      - name: Install openmp and pydy
+      - name: Install openmp
         if: runner.os == 'Linux'
         run: |
-          mamba list
-          mamba install libgomp pydy
-      - name: Install openmp and pydy
+          conda list
+          conda install libgomp
+      - name: Install openmp
         if: runner.os == 'macOS'
         run: |
-          mamba list
-          mamba install llvm-openmp pydy
+          conda list
+          conda install llvm-openmp
       # llvm-openmp fails to install because it is incompatible with ipopt, but
       # openmp "installs", nonetheless the openmp example fails to compile.
-      - name: Install openmp and pydy
+      - name: Install openmp
         if: runner.os == 'Windows'
         run: |
           mamba list
-          mamba install openmp pydy
+          mamba install openmp
       - name: Test with pytest
         run: |
-          mamba list
+          conda list
           pytest --cov=opty opty/
       - name: Install Opty and test import
         run: |
           python -m pip install --no-deps --no-build-isolation .
-          mamba list
+          conda list
           python -c "import opty"
       - name: Run an example
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Checkout Opty
         uses: actions/checkout@v4
       - name: Setup Conda environment
+        if: runner.os == 'Windows'
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
@@ -31,6 +32,15 @@ jobs:
           conda-remove-defaults: "true"
           environment-file: opty-dev-env.yml
           mamba-version: "*"
+          python-version: ${{ matrix.python-version }}
+      - name: Setup Conda environment
+        if: runner.os != 'Windows'
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          channels: conda-forge
+          conda-remove-defaults: "true"
+          environment-file: opty-dev-env.yml
           python-version: ${{ matrix.python-version }}
       - name: Install openmp
         if: runner.os == 'Linux'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
-Version 1.4.0.dev0
+Version 1.5.0.dev0
 ==================
+
+- Bump dependency minimum versions to match those in Ubuntu 22.04 (Jammy).
+
+Version 1.4.0
+=============
 
 - Dropped support for Python 3.8.
 - Added support for Python 3.13.

--- a/README.rst
+++ b/README.rst
@@ -116,8 +116,8 @@ To run all of the examples the following additional dependencies may be needed:
 - gait2d
 - pandas >= 1.3.5
 - pydy >= 0.6.0
-- pytables
-- pyyaml
+- pytables >= 3.7.0
+- pyyaml >= 5.4.1
 - symmeplot
 - yeadon >= 1.4.0
 

--- a/README.rst
+++ b/README.rst
@@ -97,29 +97,29 @@ Installation
 The required dependencies are as follows:
 
 - cyipopt >= 1.1.0 [with ipopt >= 3.11 (Linux & OSX), >= 3.13 (Windows)]
-- cython >= 0.29.19 [with a `C compiler`_]
-- numpy >= 1.19.0
+- cython >= 0.29.28 [with a `C compiler`_]
+- numpy >= 1.21.5
 - python 3.9-3.13
-- setuptools
-- sympy >= 1.6.0
+- setuptools >= 59.6.0
+- sympy >= 1.9.1
 
 .. _C compiler: https://cython.readthedocs.io/en/stable/src/quickstart/install.html
 
 The optional dependencies are as follows:
 
-- matplotlib >= 3.2.0
+- matplotlib >= 3.5.1
 - openmp
-- scipy >= 1.5.0
+- scipy >= 1.8.0
 
 To run all of the examples the following additional dependencies may be needed:
 
 - gait2d
-- pandas
-- pydy >= 0.5.0
+- pandas >= 1.3.5
+- pydy >= 0.6.0
 - pytables
 - pyyaml
 - symmeplot
-- yeadon
+- yeadon >= 1.4.0
 
 The easiest way to install opty is to first install Anaconda_ (or Miniconda_ or
 Miniforge_) and use the conda package manager to install opty and any desired

--- a/opty-dev-env.yml
+++ b/opty-dev-env.yml
@@ -3,30 +3,30 @@ channels:
   - conda-forge
 dependencies:
   # build
-  - setuptools
+  - setuptools >=59.6.0
   # run (includes optional run deps)
   - cyipopt >=1.1.0
-  - cython >=0.29.19
-  - matplotlib >=3.2.0
-  - numpy >=1.19.0
+  - cython >=0.29.28
+  - matplotlib >=3.5.1
+  - numpy >=1.21.5
   - python
-  - scipy >=1.5.0
-  - sympy >=1.13  # version required for the docs
+  - scipy >=1.8.0
+  - sympy >=1.13  # version required for the docs (1.9.1 otherwise)
   # dev
-  - coverage
-  - ipython
+  - coverage >=6.2
+  - ipython >=7.31.1
   - pytest
   - pytest-cov
   # docs/examples
   - joblib
   - numpydoc
   - pip <24  # pin required for the gait2d pip install below
-  - pydy >=0.5.0  # gait2d
+  - pydy >=0.6.0  # gait2d
   - pyyaml  # gait2d
-  - sphinx
+  - sphinx >=4.3.2
   - sphinx-gallery
   - sphinx-reredirects
   - symmeplot
-  - yeadon
+  - yeadon >=1.4.0
   - pip:
     - -e git+https://github.com/csu-hmc/gait2d#egg=gait2d

--- a/opty-dev-env.yml
+++ b/opty-dev-env.yml
@@ -15,14 +15,14 @@ dependencies:
   # dev
   - coverage >=6.2
   - ipython >=7.31.1
-  - pytest
-  - pytest-cov
+  - pytest >=6.2.5
+  - pytest-cov >=3.0.0
   # docs/examples
-  - joblib
-  - numpydoc
-  - pip <24  # pin required for the gait2d pip install below
+  - joblib >=0.17.0
+  - numpydoc >=1.2
+  - pip >=22.0.2,<24  # upper pin required for the gait2d pip install below
   - pydy >=0.6.0  # gait2d
-  - pyyaml  # gait2d
+  - pyyaml >=5.4.1  # gait2d
   - sphinx >=4.3.2
   - sphinx-gallery
   - sphinx-reredirects

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -8,14 +8,9 @@ import numpy as np
 import sympy as sm
 from sympy.physics import mechanics as me
 import cyipopt
-try:
-    plt = sm.external.import_module('matplotlib.pyplot',
-                                    __import__kwargs={'fromlist': ['']},
-                                    catch=(RuntimeError,))
-except TypeError:  # SymPy >=1.6
-    plt = sm.external.import_module('matplotlib.pyplot',
-                                    import_kwargs={'fromlist': ['']},
-                                    catch=(RuntimeError,))
+plt = sm.external.import_module('matplotlib.pyplot',
+                                __import__kwargs={'fromlist': ['']},
+                                catch=(RuntimeError,))
 
 from .utils import (ufuncify_matrix, parse_free, _optional_plt_dep,
                     _forward_jacobian, sort_sympy)

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -9,7 +9,7 @@ import sympy as sm
 from sympy.physics import mechanics as me
 import cyipopt
 plt = sm.external.import_module('matplotlib.pyplot',
-                                __import__kwargs={'fromlist': ['']},
+                                import_kwargs={'fromlist': ['']},
                                 catch=(RuntimeError,))
 
 from .utils import (ufuncify_matrix, parse_free, _optional_plt_dep,

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -22,7 +22,7 @@ import sympy.physics.mechanics as me
 from sympy.utilities.iterables import numbered_symbols
 from sympy.printing.c import C99CodePrinter
 plt = sm.external.import_module('matplotlib.pyplot',
-                                __import__kwargs={'fromlist': ['']},
+                                import_kwargs={'fromlist': ['']},
                                 catch=(RuntimeError,))
 
 __all__ = [

--- a/opty/utils.py
+++ b/opty/utils.py
@@ -21,14 +21,9 @@ import sympy as sm
 import sympy.physics.mechanics as me
 from sympy.utilities.iterables import numbered_symbols
 from sympy.printing.c import C99CodePrinter
-try:
-    plt = sm.external.import_module('matplotlib.pyplot',
-                                    __import__kwargs={'fromlist': ['']},
-                                    catch=(RuntimeError,))
-except TypeError:  # SymPy >=1.6
-    plt = sm.external.import_module('matplotlib.pyplot',
-                                    import_kwargs={'fromlist': ['']},
-                                    catch=(RuntimeError,))
+plt = sm.external.import_module('matplotlib.pyplot',
+                                __import__kwargs={'fromlist': ['']},
+                                catch=(RuntimeError,))
 
 __all__ = [
     'parse_free',

--- a/setup.py
+++ b/setup.py
@@ -17,40 +17,40 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'cyipopt>=1.1.0',
-        'cython>=0.29.19',
-        'numpy>=1.19.0',
-        'setuptools',  # provides distutils for Python >=3.13
-        'sympy>=1.6.0',
+        'cython>=0.29.28',
+        'numpy>=1.21.5',
+        'setuptools>=59.6.0',  # provides distutils for Python >=3.13
+        'sympy>=1.9.1',
     ],
     extras_require={
         'optional': [
-            'scipy>=1.5.0',
-            'matplotlib>=3.2.0',
+            'scipy>=1.8.0',
+            'matplotlib>=3.5.1',
         ],
         'examples': [
             # 'gait2d',  # when available on PyPi
-            'matplotlib>=3.2.0',
-            'pandas',
-            'pydy>=0.5.0',
+            'matplotlib>=3.5.1',
+            'pandas>=1.3.5',
+            'pydy>=0.6.0',
             'pyyaml',  # gait2d dep
-            'scipy>=1.5.0',
+            'scipy>=1.8.0',
             'symmeplot',
             'tables',
-            'yeadon',
+            'yeadon>=1.4.0',
         ],
         'doc': [
             # 'gait2d',  # when available on PyPi
             'joblib',
             'matplotlib>=3.2.0',
             'numpydoc',
-            'pydy>=0.5.0',
+            'pydy>=0.6.0',
             'pyyaml',  # gait2d dep
-            'scipy>=1.5.0',
-            'sphinx',
+            'scipy>=1.8.0',
+            'sphinx>=4.3.2',
             'sphinx-gallery',
             'sphinx-reredirects',
             'symmeplot',
-            'yeadon',
+            'yeadon>=1.4.0',
         ],
     },
     tests_require=['pytest'],

--- a/setup.py
+++ b/setup.py
@@ -32,19 +32,19 @@ setup(
             'matplotlib>=3.5.1',
             'pandas>=1.3.5',
             'pydy>=0.6.0',
-            'pyyaml',  # gait2d dep
+            'pyyaml>=5.4.1',  # gait2d dep
             'scipy>=1.8.0',
             'symmeplot',
-            'tables',
+            'tables>=3.7.0',
             'yeadon>=1.4.0',
         ],
         'doc': [
             # 'gait2d',  # when available on PyPi
-            'joblib',
-            'matplotlib>=3.2.0',
-            'numpydoc',
+            'joblib >=0.17.0',
+            'matplotlib>=3.5.1',
+            'numpydoc >=1.2',
             'pydy>=0.6.0',
-            'pyyaml',  # gait2d dep
+            'pyyaml>=5.4.1',  # gait2d dep
             'scipy>=1.8.0',
             'sphinx>=4.3.2',
             'sphinx-gallery',


### PR DESCRIPTION
See if this can help the Windows Python 3.10 from timing out in a solve.