### PR TITLE
Remove mamba in ci, only install openmp on linux.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,21 +23,7 @@ jobs:
     steps:
       - name: Checkout Opty
         uses: actions/checkout@v4
-      # NOTE : I use mamba only on Windows because conda started to fail to
-      # solve Windows builds and was timing out in CI. See
-      # https://github.com/csu-hmc/opty/pull/363 for more info.
       - name: Setup Conda environment
-        if: runner.os == 'Windows'
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          auto-update-conda: true
-          channels: conda-forge
-          conda-remove-defaults: "true"
-          environment-file: opty-dev-env.yml
-          mamba-version: "*"
-          python-version: ${{ matrix.python-version }}
-      - name: Setup Conda environment
-        if: runner.os != 'Windows'
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
@@ -50,18 +36,6 @@ jobs:
         run: |
           conda list
           conda install libgomp
-      - name: Install openmp
-        if: runner.os == 'macOS'
-        run: |
-          conda list
-          conda install llvm-openmp
-      # llvm-openmp fails to install because it is incompatible with ipopt, but
-      # openmp "installs", nonetheless the openmp example fails to compile.
-      - name: Install openmp
-        if: runner.os == 'Windows'
-        run: |
-          mamba list
-          mamba install openmp
       - name: Test with pytest
         run: |
           conda list
@@ -74,7 +48,8 @@ jobs:
       - name: Run an example
         run: |
           python examples/vyasarayani2011.py
-      # This example only seems to work on the linux builds.
+      # This example only seems to work on the linux builds, it should fail
+      # gracefully otherwise.
       - name: Run an openmp example
         run: |
           python examples/parallel_example.py


### PR DESCRIPTION
I haven't been able to get openmp to work on Windows and Mac yet in CI, so we can just remove them. Trying to install openmp on Windows may be related to the issues of the conda solver timing out. I remove mamba here, which was added as a temp fix to see if things will build.