### PR TITLE
Build docs in CI with oldest supported Python and fix f string bugs.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        # NOTE : build with the oldest supported Python here and latest
+        # supported on RTDs, to try to avoid examples not being tested for all
+        # Python versions we support.
         python-version: ['3.9']
     defaults:
       run:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.12']
+        python-version: ['3.9']
     defaults:
       run:
         shell: bash -el {0}

--- a/examples-gallery/advanced/plot_human_gait.py
+++ b/examples-gallery/advanced/plot_human_gait.py
@@ -38,11 +38,13 @@ Import all necessary modules, functions, and classes:
 """
 import os
 import pprint
+from pkg_resources import parse_version
 from opty import Problem
 from opty.utils import f_minus_ma
 from pygait2d import derive, simulate
 from pygait2d.segment import time_symbol, contact_force
 from symmeplot.matplotlib import Scene3D
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import sympy as sm
@@ -266,9 +268,14 @@ def animate():
     ], color="k")
 
     # creates a moving ground (many points to deal with matplotlib limitation)
-    scene.add_line([origin.locatenew('gl', s*ground.x)
-                    for s in np.linspace(-2.0, 2.0)],
-                   linestyle='--', color='tab:green', axlim_clip=True)
+    if parse_version(matplotlib.__version__) >= parse_version('3.10'):
+        scene.add_line([origin.locatenew('gl', s*ground.x) for s in
+                        np.linspace(-2.0, 2.0)], linestyle='--',
+                       color='tab:green', axlim_clip=True)
+    else:
+        scene.add_line([origin.locatenew('gl', s*ground.x) for s in
+                        np.linspace(-2.0, 2.0)], linestyle='--',
+                       color='tab:green')
 
     # adds CoM and unit vectors for each body segment
     for seg in segments:

--- a/examples-gallery/beginner/plot_betts_10_103_104.py
+++ b/examples-gallery/beginner/plot_betts_10_103_104.py
@@ -118,10 +118,10 @@ if info['obj_val'] < 12.8738850:
     msg = 'opty with DAE gets a better result'
 else:
     msg = 'opty with DAE gets a worse result'
-print(f'Minimal objective value achieved: {info['obj_val']:.4f},  ' +
+print(f'Minimal objective value achieved: {info["obj_val"]:.4f},  ' +
       f'as per the book it is {12.8738850}, {msg} ')
 
-obj_DAE = info['obj_val']
+obj_DAE = info["obj_val"]
 
 # %%
 # Plot the optimal state and input trajectories.
@@ -172,10 +172,10 @@ if info['obj_val'] < 12.8738850:
     msg = 'opty with ODE gets a better result'
 else:
     msg = 'opty with ODE gets a worse result'
-print(f'Minimal objective value achieved: {info['obj_val']:.4f},  ' +
+print(f'Minimal objective value achieved: {info["obj_val"]:.4f},  ' +
       f'as per the book it is {12.8738850}, {msg} ')
 
-obj_ODE = info['obj_val']
+obj_ODE = info["obj_val"]
 
 # %%
 # Plot the optimal state and input trajectories.

--- a/examples-gallery/beginner/plot_betts_10_50.py
+++ b/examples-gallery/beginner/plot_betts_10_50.py
@@ -147,9 +147,9 @@ for _ in range(1):
     solution, info = prob.solve(initial_guess)
     initial_guess = solution
     print(info['status_msg'])
-    print(f'Objective value achieved: {info['obj_val']:.4f}, as per the book '
+    print(f'Objective value achieved: {info["obj_val"]:.4f}, as per the book '
           f'it is {3.10812211}, so the error is: '
-          f'{(info['obj_val'] - 3.10812211)/3.10812211*100:.3f} % ')
+          f'{(info["obj_val"] - 3.10812211)/3.10812211*100:.3f} % ')
     print('\n')
 
 # %%

--- a/examples-gallery/beginner/plot_betts_10_7.py
+++ b/examples-gallery/beginner/plot_betts_10_7.py
@@ -88,9 +88,9 @@ tf = 10000
 num_nodes = 501
 solution, info, prob = solve_optimization(num_nodes, tf)
 print(info['status_msg'])
-print(f'Objective value achieved: {info['obj_val']:.4f}, as per the book '
+print(f'Objective value achieved: {info["obj_val"]:.4f}, as per the book '
       f'it is {6.7241}, so the error is: '
-      f'{(info['obj_val'] - 6.7241)/6.7241*100:.3f} % ')
+      f'{(info["obj_val"] - 6.7241)/6.7241*100:.3f} % ')
 
 # %%
 # Plot the optimal state and input trajectories.
@@ -114,9 +114,9 @@ tf = 8.0
 num_nodes = 10001
 solution, info, prob = solve_optimization(num_nodes, tf)
 print(info['status_msg'])
-print(f'Objective value achieved: {info['obj_val']:.4f}, as per the book '
+print(f'Objective value achieved: {info["obj_val"]:.4f}, as per the book '
       f'it is {6.7241}, so the error is: '
-      f'{(info['obj_val'] - 6.7241)/6.7241*100:.3f} % ')
+      f'{(info["obj_val"] - 6.7241)/6.7241*100:.3f} % ')
 
 # %%
 # Plot the optimal state and input trajectories.


### PR DESCRIPTION
This changes our CI setup to test build the docs with the oldest Python we support (3.9) for now. The RTDs will still run with the most recent Python we support, so the displayed docs are build with the latest and greatest. This will help ensure we don't make the examples incompatible with older versions of Python.