### PR TITLE
Add option to plot bounds on the trajectories plots.

### DIFF
--- a/examples-gallery/intermediate/plot_parallel_park.py
+++ b/examples-gallery/intermediate/plot_parallel_park.py
@@ -192,7 +192,7 @@ print(info['obj_val'])
 
 # %%
 # Plot the optimal state and input trajectories.
-_ = prob.plot_trajectories(solution)
+_ = prob.plot_trajectories(solution, show_bounds=True)
 
 # %%
 # Plot the constraint violations.

--- a/examples-gallery/intermediate/plot_parallel_park.py
+++ b/examples-gallery/intermediate/plot_parallel_park.py
@@ -160,7 +160,7 @@ instance_constraints = (
 bounds = {
     delta: (np.deg2rad(-45.0), np.deg2rad(45.0)),
     T: (-100.0, 100.0),
-    F: (-10000.0, 10000.0),
+    F: (-10000.0, np.inf),
 }
 
 # %%

--- a/examples-gallery/intermediate/plot_parallel_park.py
+++ b/examples-gallery/intermediate/plot_parallel_park.py
@@ -159,8 +159,8 @@ instance_constraints = (
 # Add some physical limits to some variables.
 bounds = {
     delta: (np.deg2rad(-45.0), np.deg2rad(45.0)),
-    T: (-100.0, 100.0),
-    F: (-10000.0, np.inf),
+    T: (-39.0, 41.0),
+    F: (-177.0, 252.0),
 }
 
 # %%

--- a/examples-gallery/intermediate/plot_parallel_park.py
+++ b/examples-gallery/intermediate/plot_parallel_park.py
@@ -159,8 +159,8 @@ instance_constraints = (
 # Add some physical limits to some variables.
 bounds = {
     delta: (np.deg2rad(-45.0), np.deg2rad(45.0)),
-    T: (-39.0, 41.0),
-    F: (-177.0, 252.0),
+    T: (-50.0, 50.0),
+    F: (-300.0, 300.0),
 }
 
 # %%

--- a/examples-gallery/intermediate/plot_parallel_park.py
+++ b/examples-gallery/intermediate/plot_parallel_park.py
@@ -182,7 +182,7 @@ initial_guess = np.ones(prob.num_free)
 initial_guess[:num_nodes] = x_guess
 initial_guess[num_nodes:2*num_nodes] = y_guess
 
-_ = prob.plot_trajectories(initial_guess)
+_ = prob.plot_trajectories(initial_guess, show_bounds=True)
 
 # %%
 # Find the optimal solution.

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -521,7 +521,7 @@ class Problem(cyipopt.Problem):
         self.obj_value.append(args[2])
 
     @_optional_plt_dep
-    def plot_trajectories(self, vector, axes=None, plot_bounds=False):
+    def plot_trajectories(self, vector, axes=None, show_bounds=False):
         """Returns the axes for two plots. The first plot displays the state
         trajectories versus time and the second plot displays the input
         trajectories versus time.
@@ -533,7 +533,7 @@ class Problem(cyipopt.Problem):
             canonical form.
         axes : ndarray of AxesSubplot, shape(n + m, )
             An array of matplotlib axes to plot to.
-        plot_bounds : bool, optional
+        show_bounds : bool, optional
             If True, the bounds will be plotted in the plot of the respective
             trajectory.
 
@@ -601,14 +601,14 @@ class Problem(cyipopt.Problem):
             ax.plot(time, traj)
             ax.set_ylabel(sm.latex(symbol, mode='inline'))
 
-            if self.bounds is not None and plot_bounds:
+            if self.bounds is not None and show_bounds:
                 if symbol in self.bounds.keys():
                     if self.bounds[symbol][0] not in [-np.inf, np.inf]:
-                        ax.axhline(self.bounds[symbol][0], color='black',
-                                lw=0.5, linestyle='--')
+                        ax.axhline(self.bounds[symbol][0], color='C1',
+                                lw=1.0, linestyle='--')
                     if self.bounds[symbol][1] not in [-np.inf, np.inf]:
-                        ax.axhline(self.bounds[symbol][1], color='black',
-                            lw=0.5, linestyle='--')
+                        ax.axhline(self.bounds[symbol][1], color='C1',
+                            lw=1.0, linestyle='--')
         ax.set_xlabel('Time')
         axes[0].set_title('State Trajectories')
         if (self.collocator.num_unknown_input_trajectories +

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -521,7 +521,7 @@ class Problem(cyipopt.Problem):
         self.obj_value.append(args[2])
 
     @_optional_plt_dep
-    def plot_trajectories(self, vector, axes=None):
+    def plot_trajectories(self, vector, axes=None, plot_bounds=False):
         """Returns the axes for two plots. The first plot displays the state
         trajectories versus time and the second plot displays the input
         trajectories versus time.
@@ -533,6 +533,9 @@ class Problem(cyipopt.Problem):
             canonical form.
         axes : ndarray of AxesSubplot, shape(n + m, )
             An array of matplotlib axes to plot to.
+        plot_bounds : bool, optional
+            If True, the bounds will be plotted in the plot of the respective
+            trajectory.
 
         Returns
         =======
@@ -597,6 +600,15 @@ class Problem(cyipopt.Problem):
         for ax, traj, symbol in zip(axes, trajectories, traj_syms):
             ax.plot(time, traj)
             ax.set_ylabel(sm.latex(symbol, mode='inline'))
+
+            if self.bounds is not None and plot_bounds:
+                if symbol in self.bounds.keys():
+                    if self.bounds[symbol][0] not in [-np.inf, np.inf]:
+                        ax.axhline(self.bounds[symbol][0], color='black',
+                                lw=0.5, linestyle='--')
+                    if self.bounds[symbol][1] not in [-np.inf, np.inf]:
+                        ax.axhline(self.bounds[symbol][1], color='black',
+                            lw=0.5, linestyle='--')
         ax.set_xlabel('Time')
         axes[0].set_title('State Trajectories')
         if (self.collocator.num_unknown_input_trajectories +

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -561,12 +561,10 @@ class Problem(cyipopt.Problem):
 
             if self.bounds is not None and show_bounds:
                 if symbol in self.bounds.keys():
-                    if self.bounds[symbol][0] not in [-np.inf, np.inf]:
-                        ax.axhline(self.bounds[symbol][0], color='C1',
-                                lw=1.0, linestyle='--')
-                    if self.bounds[symbol][1] not in [-np.inf, np.inf]:
-                        ax.axhline(self.bounds[symbol][1], color='C1',
-                            lw=1.0, linestyle='--')
+                    ax.axhline(self.bounds[symbol][0], color='C1',
+                                           lw=1.0, linestyle='--')
+                    ax.axhline(self.bounds[symbol][1], color='C1',
+                                           lw=1.0, linestyle='--')
         ax.set_xlabel('Time')
         axes[0].set_title('State Trajectories')
         if (self.collocator.num_unknown_input_trajectories +


### PR DESCRIPTION
Added an optional kwarg ``plot_bounds`` If true, bounds will be plotted in the plots of the respective trajectory, unless they are np.inf, or -np.inf Takes care of Q&A #414 
I tested with around 15 simulations.