### PR TITLE
Support for inequality constraints.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -23,3 +23,8 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	rm -rf $(BUILDDIR)/*
+	rm -rf examples/
+	rm -rf sg_execution_times.rst

--- a/examples-gallery/beginner/plot_betts_10_50.py
+++ b/examples-gallery/beginner/plot_betts_10_50.py
@@ -28,7 +28,6 @@ can be added: :math:`q_i(t) = x_i(t) + u_i(t)`, and then use bounds on
 **States**
 
 - :math:`x_1, x_2, x_3. x_4. x_5, x_6` : state variables
-- :math:`q_1, q_2, q_3. q_4. q_5, q_6` : state variables for the inequalities
 
 **Controls**
 
@@ -60,7 +59,7 @@ eom = sm.Matrix([
     -x4.diff(t) + x3*u2,
     -x5.diff(t) + x4*u3,
     -x6.diff(t) + x5*u4,
-    u1 + x1,  # 0.3 >= c >= inf
+    u1 + x1,
     u2 + x2,
     u3 + x3,
     u4 + x4,
@@ -97,7 +96,6 @@ obj, obj_grad = create_objective_function(
 
 # %%
 # Specify the instance constraints and bounds
-
 instance_constraints = (
     x1.func(t0) - 1.0,
     x2.func(t0) - x1.func(tf),
@@ -114,6 +112,26 @@ instance_constraints = (
 )
 
 # %%
+#
+# .. math::
+#
+#    0.3 \leq u_1 + x_1 \leq \inf
+#    0.3 \leq u_2 + x_2 \leq \inf
+#    0.3 \leq u_3 + x_3 \leq \inf
+#    0.3 \leq u_4 + x_4 \leq \inf
+#    0.3 \leq u_5 + x_5 \leq \inf
+#    0.3 \leq u_6 + x_6 \leq \inf
+
+eom_bounds = {
+    6: (0.3, np.inf),
+    7: (0.3, np.inf),
+    8: (0.3, np.inf),
+    9: (0.3, np.inf),
+    10: (0.3, np.inf),
+    11: (0.3, np.inf),
+}
+
+# %%
 # Solve the Optimization Problem
 # ------------------------------
 prob = Problem(
@@ -126,10 +144,7 @@ prob = Problem(
     instance_constraints=instance_constraints,
     time_symbol=t,
     backend='numpy',
-    eom_lower_bound=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                     0.3, 0.3, 0.3, 0.3, 0.3, 0.3],
-    eom_upper_bound=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                     np.inf, np.inf, np.inf, np.inf, np.inf, np.inf],
+    eom_bounds=eom_bounds,
 )
 
 prob.add_option('max_iter', 1000)
@@ -154,21 +169,11 @@ _ = prob.plot_trajectories(solution, show_bounds=True)
 
 # %%
 # Plot the constraint violations.
-_ = prob.plot_constraint_violations(solution)
+_ = prob.plot_constraint_violations(solution, subplots=True)
 
 # %%
 # Plot the objective function.
 _ = prob.plot_objective_value()
-
-# %%
-# Are the inequality constraints satisfied?
-min_q = np.min(solution[7*num_nodes:12*num_nodes-1])
-if min_q >= 0.3:
-    print(f"Minimal value of the q\u1D62 is: {min_q:.12f} >= 0.3, "
-          f"so satisfied.")
-else:
-    print(f"Minimal value of the q\u1D62 is: {min_q:.12f} < 0.3, "
-          f"so not satisfied.")
 
 # %%
 # sphinx_gallery_thumbnail_number = 2

--- a/examples-gallery/beginner/plot_betts_10_50.py
+++ b/examples-gallery/beginner/plot_betts_10_50.py
@@ -171,7 +171,7 @@ _ = prob.plot_trajectories(solution)
 
 # %%
 # Plot the constraint violations.
-# sphinx_gallery_thumbnail_number = 3
+# sphinx_gallery_thumbnail_number = 2
 _ = prob.plot_constraint_violations(solution)
 
 # %%

--- a/examples-gallery/beginner/plot_betts_10_50.py
+++ b/examples-gallery/beginner/plot_betts_10_50.py
@@ -166,12 +166,8 @@ print(f'Objective value achieved: {info["obj_val"]: .4f}, as per the book '
 print('\n')
 
 # %%
-# Plot the sparsity of the NLP Jacobian.
-_ = prob.plot_jacobian_sparsity()
-
-# %%
 # Plot the optimal state and input trajectories.
-_ = prob.plot_trajectories(solution, show_bounds=True)
+_ = prob.plot_trajectories(solution)
 
 # %%
 # Plot the constraint violations.

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -715,6 +715,12 @@ class Problem(cyipopt.Problem):
         instance_violations = con_violations[len(eom_violations):]
         eom_violations = eom_violations.reshape((self.collocator.num_eom,
                                                  N - 1))
+        # TODO : figure out a way to plot the inequality constraint violations
+        # don't plot inequality
+        if self.eom_bounds is not None:
+            for k, v in self.eom_bounds.items():
+                eom_violations[k] = np.nan
+
         con_nodes = range(1, self.collocator.num_collocation_nodes)
 
         if axes is None:
@@ -741,8 +747,15 @@ class Problem(cyipopt.Problem):
 
         else:
             for i in range(self.collocator.num_eom):
-                axes[i].plot(con_nodes, eom_violations[i])
-                axes[i].set_ylabel(f'Eq. {str(i+1)} \n violation', fontsize=9)
+                if ((self.eom_bounds is not None) and
+                    (i in self.eom_bounds.keys())):  # don't plot if inequality
+                    axes[i].plot(con_nodes, np.nan*np.ones_like(con_nodes))
+                    axes[i].set_ylabel(f'Eq. {str(i+1)} \n not shown',
+                                       fontsize=9)
+                else:
+                    axes[i].plot(con_nodes, eom_violations[i])
+                    axes[i].set_ylabel(f'Eq. {str(i+1)} \n violation',
+                                       fontsize=9)
                 if i < self.collocator.num_eom - 1:
                     axes[i].set_xticklabels([])
             axes[num_eom_plots-1].set_xlabel('Node Number')

--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -826,11 +826,13 @@ class Problem(cyipopt.Problem):
         return ax
 
     @_optional_plt_dep
-    def plot_jacobian_sparsity(self, ax=None):
+    def _plot_jacobian_sparsity(self, ax=None):
+        # TODO : Make this a public method.
         # %%
         # Visualize the sparseness of the Jacobian for the non-linear programming
         # problem.
 
+        # TODO : Figure out how to not depend on scipy if possible.
         from scipy.sparse import coo_matrix
         jac_vals = self.jacobian(np.ones(self.num_free))
         row_idxs, col_idxs = self.jacobianstructure()

--- a/opty/tests/test_direct_collocation.py
+++ b/opty/tests/test_direct_collocation.py
@@ -131,8 +131,7 @@ def test_pendulum():
         time_symbol=t,
         bounds={T(t): (-2.0, 2.0)},
         show_compile_output=True,
-        eom_lower_bound=[-20.0, -10.0],
-        eom_upper_bound=[20.0, 10.0],
+        eom_bounds={0: (-20.0, 20.0), 1: (-10.0, 10.0)},
     )
 
     assert prob.collocator.num_instance_constraints == 4


### PR DESCRIPTION
Fixes #156

New kwargs added to Problem that allow a user to set lower and upper bounds for each equation in the equations of motion. This allows inequality path constraints to be added to the essential differential equations. Caution should be used when added lower and upper bounds other than 0 to the essential differential equations, but it is supported.

Things to consider:

- Should we somehow prevent the user from giving inequality bounds to the essential equations of motion? I think these should always be equality constraints (otherwise you are not abiding by Newton's Laws in dynamics problems). If we should prevent the user, how do we identify which equations should strictly be equality constraints?
- What is the easiest way to indicate that an equation in the equations of motion should have bounds?
- Should we allow the constraint bounds to vary with time? It may already be allowed if you include the `time(t)` style hack. Not sure though.

# TODO

- [x] Figure out how to handle `plot_constraint_violations` if inequalities are present.