### PR TITLE
Support inputs that are variables and their derivatives.

### DIFF
--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -1537,10 +1537,10 @@ class ConstraintCollocator(object):
         time_varying_symbols = me.find_dynamicsymbols(self.eom)
         state_related = states.union(states_derivatives)
         non_states = time_varying_symbols.difference(state_related)
-        if sm.Matrix(list(non_states)).has(sm.Derivative):
-            msg = ('Too few state variables provided for state time '
-                   'derivatives found in equations of motion.')
-            raise ValueError(msg)
+        #if sm.Matrix(list(non_states)).has(sm.Derivative):
+            #msg = ('Too few state variables provided for state time '
+                   #'derivatives found in equations of motion.')
+            #raise ValueError(msg)
 
         res = self._parse_inputs(non_states,
                                  self.known_trajectory_map.keys())


### PR DESCRIPTION
It is common for kinematically driven dynamics models that the inputs are a position, it's derivative, and it's double derivative. The bicycle countersteer example is one such example. We currently need a hack to support this. The hack being adding an extra differential equation.

This PR doesn't use the hack but fails silently, i.e. it solves but with an incorrect solution.

The discretized equations of motion do not treat the derivative term correctly:

```
In [3]: prob.collocator.discrete_eom
Out[3]: 
Matrix([
[                                                                                                                                                                       -omegai + (thetai - thetap)/Delta_t],
[-g*h*m*sin(thetai) + h*m*(Derivativei*a*v/(b*cos(deltai)**2) + v*tan(deltai))*cos(thetai) + v**2*(-I2 + I3 - h**2*m)*sin(thetai)*cos(thetai)*tan(deltai)**2/b**2 + (I1 + h**2*m)*(omegai - omegap)/Delta_t],
[                                                                                                                                                                          -v*cos(psii) + (xi - xp)/Delta_t],
[                                                                                                                                                                          -v*sin(psii) + (yi - yp)/Delta_t],
[                                                                                                                                                                  -v*tan(deltai)/b + (psii - psip)/Delta_t]])

In [4]: prob.collocator.discrete_eom.free_symbols
Out[4]: 
{Delta_t,
 Derivativei,
 I1,
 I2,
 I3,
 a,
 b,
 deltai,
 g,
 h,
 m,
 omegai,
 omegap,
 psii,
 psip,
 thetai,
 thetap,
 v,
 xi,
 xp,
 yi,
 yp}
```