### PR TITLE
remove known_trajectory_symbols. Should fix #495

### DIFF
--- a/opty/direct_collocation.py
+++ b/opty/direct_collocation.py
@@ -1227,13 +1227,6 @@ class ConstraintCollocator(object):
         """
         return self._known_trajectory_map
 
-    @property
-    def known_trajectory_symbols(self):
-        """
-        The known trajectory symbols.
-        Type: (m-q)-tuple
-        """
-        return self._known_trajectory_symbols
 
     @property
     def next_known_discrete_specified_symbols(self):
@@ -1329,7 +1322,7 @@ class ConstraintCollocator(object):
     @property
     def num_known_input_trajectories(self):
         """
-        The number of known trajectories = len(known_trajectory_symbols).
+        The number of known trajectories = len(known_input_trajectories).
         Type: int
         """
         return self._num_known_input_trajectories


### PR DESCRIPTION
I did not find ``_known_trajectory_symbols`` anywhere in ``direct_collocation.py``.
So I removed that property / method.
Thr correct name seems to be ``-known_input_trajectories``
