### PR TITLE
added a pointer to examples in pst-notebooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,10 @@ Animations from some of the `examples
      - .. image:: https://opty.readthedocs.io/latest/_images/sphx_glr_plot_park2004_thumb.gif
           :width: 200px
 
+Some more examples may be found here:
+https://pydy.github.io/pst-notebooks
+
+
 Installation
 ============
 


### PR DESCRIPTION
I added the link to pst-notebooks, as there are a number of further examples using opty